### PR TITLE
Prevent scroll when dragging a node

### DIFF
--- a/js/jsmind.draggable.js
+++ b/js/jsmind.draggable.js
@@ -259,6 +259,7 @@
         drag:function(e){
             if(!this.jm.get_editable()){return;}
             if(this.capture){
+                e.preventDefault();
                 this.show_shadow();
                 this.moved = true;
                 clear_selection();


### PR DESCRIPTION
When use with a touch device, drag a node should not scroll the canvas.
If a node is not beeing dragged, scroll works as usual.