### PR TITLE
Add a method to enable rotate the background in a image node

### DIFF
--- a/js/jsmind.draggable.js
+++ b/js/jsmind.draggable.js
@@ -88,6 +88,7 @@
             s.height = el.style.height;
             s.backgroundImage = el.style.backgroundImage;
             s.backgroundSize = el.style.backgroundSize;
+            s.transform = el.style.transform;
             this.shadow_w = this.shadow.clientWidth;
             this.shadow_h = this.shadow.clientHeight;
 

--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -1531,7 +1531,7 @@
             }
         },
 
-        set_node_background_image:function(nodeid, image, width, height){
+        set_node_background_image:function(nodeid, image, width, height, angle){
             if(this.get_editable()){
                 var node = this.mind.get_node(nodeid);
                 if(!!node){
@@ -1544,6 +1544,9 @@
                     if(!!height){
                         node.data['height'] = height;
                     }
+                    if(!!angle){
+                        node.data['angle'] = angle;
+                    }
                     this.view.reset_node_custom_style(node);
                     this.view.update_node(node);
                     this.layout.layout();
@@ -1555,6 +1558,25 @@
             }
         },
 
+        set_node_background_angle:function(nodeid, angle){
+            if(this.get_editable()){
+                var node = this.mind.get_node(nodeid);
+                if(!!node){
+                    if(!node.data['background-image']) {
+                        logger.error('fail, only can change aangle of node with background image');
+                        return null;
+                    }
+                    node.data['angle'] = angle;
+                    this.view.reset_node_custom_style(node);
+                    this.view.update_node(node);
+                    this.layout.layout();
+                    this.view.show(false);
+                }
+            }else{
+                logger.error('fail, this mind map is not editable');
+                return null;
+            }
+        },
 
         resize:function(){
             this.view.resize();
@@ -2535,6 +2557,11 @@
                     node_element.style.backgroundImage='url('+backgroundImage+')';
                 }
                 node_element.style.backgroundSize='99%';
+
+                if('angle' in node_data){
+                    node_element.style.transform = 'rotate(' + node_data['angle'] + 'deg)';
+                }
+
             }
         },
 

--- a/js/jsmind.screenshot.js
+++ b/js/jsmind.screenshot.js
@@ -80,15 +80,20 @@
         }
     };
 
-    jcanvas.image = function(ctx,backgroundUrl,x,y,w,h,r,callback){
+    jcanvas.image = function(ctx,backgroundUrl,x,y,w,h,r, angle, callback){
         var img = new Image();
         img.onload = function () {
             ctx.save();
+            ctx.translate(x,y);
+            ctx.save();
             ctx.beginPath();
-            jcanvas.rect(ctx,x,y,w,h,r);
+            jcanvas.rect(ctx,0,0,w,h,r);
             ctx.closePath();
             ctx.clip();
-            ctx.drawImage(img,x,y,w,h);
+            ctx.translate(w/2,h/2);
+            ctx.rotate(angle*Math.PI/180);
+            ctx.drawImage(img,-w/2,-h/2);
+            ctx.restore();
             ctx.restore();
             callback();
         }
@@ -245,7 +250,11 @@
             if ('background-image' in node.data) {
                 var backgroundUrl = css(ncs,'background-image').slice(5, -2);
                 node.ready = false;
-                jcanvas.image(ctx, backgroundUrl, rb.x, rb.y, rb.w, rb.h, round_radius,
+                var angle = 0;
+                if ('angle' in node.data) {
+                    angle = node.data['angle'];
+                }
+                jcanvas.image(ctx, backgroundUrl, rb.x, rb.y, rb.w, rb.h, round_radius, angle,
                     function() {
                         node.ready = true;
                     });


### PR DESCRIPTION
The change is also applied to drag and screenshot features.

The angle is set as a number. Tested with 0, 90, 180 and 270 degrees.
