### PR TITLE
add 简单支持组合按键事件

### DIFF
--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -2754,6 +2754,13 @@
             var evt = e || event;
             if (!this.opts.enable) { return true; }
             var kc = evt.keyCode;
+
+            //combine keyCode
+            var combine = ((e.ctrlKey || e.metaKey) || 0) * 1000;
+            if (combine === 0) combine = (e.altKey || 0) * 2000;
+            if (combine === 0) combine = (e.shiftKey || 0) * 3000;
+            kc += combine;
+
             if (kc in this._mapping) {
                 this._mapping[kc].call(this, this.jm, e);
             }


### PR DESCRIPTION
通过将功能键分配到 1000以上的数字来实现简单的组合按键方式，之所以采用这种方式而没有采用组合keyCode为字符串的形式是为了尽可能的不改变原有的逻辑。
