### PR TITLE
support to draw lines with svg to improve performance

### DIFF
--- a/example/2_features.html
+++ b/example/2_features.html
@@ -147,7 +147,10 @@
         var options = {
             container:'jsmind_container',
             theme:'greensea',
-            editable:true
+            editable:true,
+            view:{
+                engine:'svg'
+            }
         }
         _jm = jsMind.show(options);
         // _jm = jsMind.show(options,mind);
@@ -257,7 +260,7 @@
         if(!selected_node){prompt_info('please select a node first.');return;}
 
         var nodeid = jsMind.util.uuid.newid();
-        var topic = '* Node_'+nodeid.substr(0,5)+' *';
+        var topic = '* Node_'+nodeid.substr(nodeid.length-6)+' *';
         var node = _jm.add_node(selected_node, nodeid, topic);
     }
 

--- a/js/jsmind.draggable.js
+++ b/js/jsmind.draggable.js
@@ -15,8 +15,6 @@
     if (typeof jsMind.draggable != 'undefined') { return; }
 
     var jdom = jsMind.util.dom;
-    var jcanvas = jsMind.util.canvas;
-
     var clear_selection = 'getSelection' in $w ? function () {
         $w.getSelection().removeAllRanges();
     } : function () {
@@ -104,22 +102,25 @@
             this.shadow.style.visibility = 'hidden';
         },
 
-        clear_lines: function () {
-            jcanvas.clear(this.canvas_ctx, 0, 0, this.jm.view.size.w, this.jm.view.size.h);
-        },
-
         _magnet_shadow: function (node) {
             if (!!node) {
                 this.canvas_ctx.lineWidth = options.line_width;
                 this.canvas_ctx.strokeStyle = 'rgba(0,0,0,0.3)';
                 this.canvas_ctx.lineCap = 'round';
-                this.clear_lines();
-                jcanvas.lineto(this.canvas_ctx,
-                    node.sp.x,
-                    node.sp.y,
-                    node.np.x,
-                    node.np.y);
+                this._clear_lines();
+                this._canvas_lineto(node.sp.x, node.sp.y, node.np.x, node.np.y);
             }
+        },
+
+        _clear_lines: function () {
+            this.canvas_ctx.clearRect(0, 0, this.jm.view.size.w, this.jm.view.size.h);
+        },
+
+        _canvas_lineto: function (x1, y1, x2, y2) {
+            this.canvas_ctx.beginPath();
+            this.canvas_ctx.moveTo(x1, y1);
+            this.canvas_ctx.lineTo(x2, y2);
+            this.canvas_ctx.stroke();
         },
 
         _lookup_close_node: function () {
@@ -281,12 +282,12 @@
                 if (this.hlookup_delay != 0) {
                     $w.clearTimeout(this.hlookup_delay);
                     this.hlookup_delay = 0;
-                    this.clear_lines();
+                    this._clear_lines();
                 }
                 if (this.hlookup_timer != 0) {
                     $w.clearInterval(this.hlookup_timer);
                     this.hlookup_timer = 0;
-                    this.clear_lines();
+                    this._clear_lines();
                 }
                 if (this.moved) {
                     var src_node = this.active_node;

--- a/js/jsmind.screenshot.js
+++ b/js/jsmind.screenshot.js
@@ -25,7 +25,7 @@
         var display = css(cstyle, 'display');
         return (visibility !== 'hidden' && display !== 'none');
     };
-    var jcanvas = jsMind.util.canvas;
+    var jcanvas = {};
     jcanvas.rect = function (ctx, x, y, w, h, r) {
         if (w < 2 * r) r = w / 2;
         if (h < 2 * r) r = h / 2;
@@ -80,7 +80,7 @@
         }
     };
 
-    jcanvas.image = function (ctx, backgroundUrl, x, y, w, h, r, rotation, callback) {
+    jcanvas.image = function (ctx, url, x, y, w, h, r, rotation, callback) {
         var img = new Image();
         img.onload = function () {
             ctx.save();
@@ -95,9 +95,9 @@
             ctx.drawImage(img, -w / 2, -h / 2);
             ctx.restore();
             ctx.restore();
-            callback();
+            !!callback && callback();
         }
-        img.src = backgroundUrl;
+        img.src = url;
     };
 
     jsMind.screenshot = function (jm) {
@@ -123,26 +123,23 @@
 
         shoot: function (callback) {
             this.init();
-            var jms = this;
             this._draw(function () {
-                if (!!callback) {
-                    callback(jms);
-                }
-                jms.clean();
-            });
+                !!callback && callback();
+                this.clean();
+            }.bind(this));
             this._watermark();
         },
 
         shootDownload: function () {
-            this.shoot(function (jms) {
-                jms._download();
-            });
+            this.shoot(function () {
+                this._download();
+            }.bind(this));
         },
 
         shootAsDataURL: function (callback) {
-            this.shoot(function (jms) {
-                callback(jms.canvas_elem.toDataURL());
-            });
+            this.shoot(function () {
+                !!callback && callback(this.canvas_elem.toDataURL());
+            }.bind(this));
         },
 
         resize: function () {
@@ -161,8 +158,9 @@
             var ctx = this.canvas_ctx;
             ctx.textAlign = 'left';
             ctx.textBaseline = 'top';
-            this._draw_lines();
-            this._draw_nodes(callback);
+            this._draw_lines(function () {
+                this._draw_nodes(callback);
+            }.bind(this));
         },
 
         _watermark: function () {
@@ -177,8 +175,8 @@
             ctx.fillText($w.location, 5.5, c.height - 2.5);
         },
 
-        _draw_lines: function () {
-            this.jm.view.show_lines(this.canvas_ctx);
+        _draw_lines: function (callback) {
+            this.jm.view.graph.copy_to(this.canvas_ctx, callback);
         },
 
         _draw_nodes: function (callback) {

--- a/style/jsmind.css
+++ b/style/jsmind.css
@@ -19,6 +19,7 @@
 }
 
 /* z-index:1 */
+svg{position:absolute;z-index:1;}
 canvas{position:absolute;z-index:1;}
 
 /* z-index:2 */


### PR DESCRIPTION
基于 issue #187 的讨论，为 jsMind 增加选项 view.engine 用于切换线条的绘制的方式。

该选项可配置为 canvas(默认) 或 svg。