### PR TITLE
prevent tab to change focus in browser

### DIFF
--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -2844,6 +2844,7 @@
         },
 
         handler: function (e) {
+            if (e.which == 9) { e.preventDefault(); } //prevent tab to change focus in browser
             if (this.jm.view.is_editing()) { return; }
             var evt = e || event;
             if (!this.opts.enable) { return true; }


### PR DESCRIPTION
In the Mindmap-Tool Xmind the Tab key is used to create child nodes. When i want to use tab in jsmind the browser change focus after first tab.

This fix allow you tu usse the tab key for any operation