### PR TITLE
修改svg的class的赋值方式

### DIFF
--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -2222,7 +2222,7 @@
         this.view = view;
         this.opts = view.opts;
         this.e_svg = jm.graph_svg.c('svg');
-        this.e_svg.className = 'jsmind';
+        this.e_svg.setAttribute('class', 'jsmind');
         this.size = { w: 0, h: 0 };
         this.lines = [];
     };


### PR DESCRIPTION
修复在使用svg的报错：Cannot assign to read only property 'className' of object '[object SVGSVGElement]'