### PR TITLE
Draggable option (hizzgdev#323)

### DIFF
--- a/docs/en/2.options.md
+++ b/docs/en/2.options.md
@@ -29,13 +29,13 @@ options = {
    theme : null, 			// theme
    mode :'full', 			// display mode
    support_html : true, 	// Does it support HTML elements in the node?
-   draggable: false,        // Drag the mind map with your mouse, when it's larger that the container
    view:{
        engine: 'canvas', 	// engine for drawing lines between nodes in the mindmap
        hmargin:100, 		// Minimum horizontal distance of the mindmap from the outer frame of the container
        vmargin:50, 			// Minimum vertical distance of the mindmap from the outer frame of the container
        line_width:2, 		// thickness of the mindmap line
-       line_color:'#555' 	// Thought mindmap line color
+       line_color:'#555', 	// Thought mindmap line color
+       draggable: false,    // Drag the mind map with your mouse, when it's larger that the container
    },
    layout:{
        hspace:30, 			// horizontal spacing between nodes
@@ -98,11 +98,6 @@ These options are described in more detail below.
 
 > Note that in freemind, the style of the node is controlled using the HTML language, and it is recommended to set this parameter to true if you are using data in freemind format.
 
-**draggable** : (bool) Do you want whole mind map draggable inside container?
-
-> The default value of this parameter is false, as it keep the default behavior with vertical and horizontal scrollbar on the container when mind map is bigger than the container.
-> Otherwise, if true, there is no more scrollbars, instead you can drag the mind map with your mouse, while button is down.
-
 2.3 Layout Options
 ===
 
@@ -122,6 +117,11 @@ These options are described in more detail below.
 **view.line_color** : (string) color of the mindmap line (color representation in HTML)
 
 > These two parameters determine the style of the lines in the mindmap. By default, the lines are 2px in thickness and dark gray in color (#555).
+
+**view.draggable** : (bool) Do you want whole mind map draggable inside container?
+
+> The default value of this parameter is false, as it keep the default behavior with vertical and horizontal scrollbar on the container when mind map is bigger than the container.
+> Otherwise, if true, there is no more scrollbars, instead you can drag the mind map with your mouse, while button is down.
 
 **layout.hspace** : horizontal distance (pixels) between (number) nodes  
 **layout.vspace** : vertical spacing (pixels) between (number) nodes

--- a/docs/en/2.options.md
+++ b/docs/en/2.options.md
@@ -36,7 +36,7 @@ options = {
        line_width:2, 		// thickness of the mindmap line
        line_color:'#555', 	// Thought mindmap line color
        draggable: false,    // Drag the mind map with your mouse, when it's larger that the container
-       hide_scrollbars: false // Hide container scrollbars, when mind map is larger than container and draggable option is true.
+       hide_scrollbars_when_draggable: false // Hide container scrollbars, when mind map is larger than container and draggable option is true.
    },
    layout:{
        hspace:30, 			// horizontal spacing between nodes
@@ -123,7 +123,7 @@ These options are described in more detail below.
 
 > The default value of this parameter is false, as it keep the default behavior with vertical and horizontal scrollbars on the container when mind map is bigger than the container.
 
-**view.hide_scrollbars** : (bool) Do you want to hide container scrollbars?
+**view.hide_scrollbars_when_draggable** : (bool) Do you want to hide container scrollbars?
 
 > Rely on draggable option activation, as otherwise it wouldn't be possible to explore the whole mind map when it's bigger than the container.
 > The default value of this parameter is false, as it keep the default behavior with vertical and horizontal scrollbars on the container when mind map is bigger than the container.

--- a/docs/en/2.options.md
+++ b/docs/en/2.options.md
@@ -29,6 +29,7 @@ options = {
    theme : null, 			// theme
    mode :'full', 			// display mode
    support_html : true, 	// Does it support HTML elements in the node?
+   draggable: false,        // Drag the mind map with your mouse, when it's larger that the container
    view:{
        engine: 'canvas', 	// engine for drawing lines between nodes in the mindmap
        hmargin:100, 		// Minimum horizontal distance of the mindmap from the outer frame of the container
@@ -96,6 +97,11 @@ These options are described in more detail below.
 > The default value of this parameter is true, meaning that it allows HTML code to be used in the node's header, and you can even insert a table `<table>` in the node's header if you wish. If you want only plain text in the title, set this parameter to false .
 
 > Note that in freemind, the style of the node is controlled using the HTML language, and it is recommended to set this parameter to true if you are using data in freemind format.
+
+**draggable** : (bool) Do you want whole mind map draggable inside container?
+
+> The default value of this parameter is false, as it keep the default behavior with vertical and horizontal scrollbar on the container when mind map is bigger than the container.
+> Otherwise, if true, there is no more scrollbars, instead you can drag the mind map with your mouse, while button is down.
 
 2.3 Layout Options
 ===

--- a/docs/en/2.options.md
+++ b/docs/en/2.options.md
@@ -36,6 +36,7 @@ options = {
        line_width:2, 		// thickness of the mindmap line
        line_color:'#555', 	// Thought mindmap line color
        draggable: false,    // Drag the mind map with your mouse, when it's larger that the container
+       hide_scrollbars: false // Hide container scrollbars, when mind map is larger than container and draggable option is true.
    },
    layout:{
        hspace:30, 			// horizontal spacing between nodes
@@ -120,8 +121,13 @@ These options are described in more detail below.
 
 **view.draggable** : (bool) Do you want whole mind map draggable inside container?
 
-> The default value of this parameter is false, as it keep the default behavior with vertical and horizontal scrollbar on the container when mind map is bigger than the container.
-> Otherwise, if true, there is no more scrollbars, instead you can drag the mind map with your mouse, while button is down.
+> The default value of this parameter is false, as it keep the default behavior with vertical and horizontal scrollbars on the container when mind map is bigger than the container.
+
+**view.hide_scrollbars** : (bool) Do you want to hide container scrollbars?
+
+> Rely on draggable option activation, as otherwise it wouldn't be possible to explore the whole mind map when it's bigger than the container.
+> The default value of this parameter is false, as it keep the default behavior with vertical and horizontal scrollbars on the container when mind map is bigger than the container.
+> Otherwise, if true, there is no more scrollbars, and instead you can drag the mind map with your mouse, while button is down.
 
 **layout.hspace** : horizontal distance (pixels) between (number) nodes  
 **layout.vspace** : vertical spacing (pixels) between (number) nodes

--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -12,7 +12,7 @@
     // __name__ should be a const value, Never try to change it easily.
     var __name__ = 'jsMind';
     // library version
-    var __version__ = '0.4.6';
+    var __version__ = '0.4.7';
     // author
     var __author__ = 'hizzgdev@163.com';
 
@@ -54,6 +54,7 @@
         theme: null,
         mode: 'full',    // full or side
         support_html: true,
+        draggable: false, // drag the mind map with your mouse, when it's larger that the container
 
         view: {
             engine: 'canvas',
@@ -1099,6 +1100,8 @@
             this._event_bind();
 
             jm.init_plugins(this);
+
+            this._drag_nodes()
         },
 
         enable_edit: function () {
@@ -1665,6 +1668,31 @@
             var l = this.event_handles.length;
             for (var i = 0; i < l; i++) {
                 this.event_handles[i](type, data);
+            }
+        },
+
+        // Drag the whole mind map with your mouse, when it's larger that the container
+        _drag_nodes: function () {
+            if (this.options.draggable) {
+                // Avoid scrollbars when mind map is larger than the container (e_panel = jsmind-inner)
+                this.view.e_panel.style = 'overflow: hidden'
+                // Move the whole mind map with mouse moves, while button is down.
+                this.view.container.onmousedown = (eventDown) => {
+                    // Record initial mouse position.
+                    let x = eventDown.clientX
+                    let y = eventDown.clientY
+                    // Stop moving mind map once mouse button is released.
+                    this.view.container.onmouseup = () => {
+                        this.view.container.onmousemove = null
+                    }
+                    // Follow current mouse position and move mind map accordingly.
+                    this.view.container.onmousemove = (eventMove) => {
+                        this.view.e_panel.scrollBy(x - eventMove.clientX, y - eventMove.clientY)
+                        // Record new reference position.
+                        x = eventMove.clientX
+                        y = eventMove.clientY
+                    }
+                }
             }
         }
 
@@ -3027,4 +3055,3 @@
         $w[__name__] = jm;
     }
 })(typeof window !== 'undefined' ? window : global);
-

--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -62,7 +62,7 @@
             line_width: 2,
             line_color: '#555',
             draggable: false, // drag the mind map with your mouse, when it's larger that the container
-            hide_scrollbars: false // hide container scrollbars, when mind map is larger than container and draggable option is true.
+            hide_scrollbars_when_draggable: false // hide container scrollbars, when mind map is larger than container and draggable option is true.
         },
         layout: {
             hspace: 30,
@@ -1087,7 +1087,7 @@
                 line_width: opts.view.line_width,
                 line_color: opts.view.line_color,
                 draggable: opts.view.draggable,
-                hide_scrollbars: opts.view.hide_scrollbars
+                hide_scrollbars_when_draggable: opts.view.hide_scrollbars_when_draggable
             };
             // create instance of function provider
             this.data = new jm.data_provider(this);
@@ -2342,7 +2342,7 @@
 
             this.container.appendChild(this.e_panel);
 
-            this._drag_nodes()
+            this.enable_draggable_canvas()
         },
 
         add_event: function (obj, event_name, event_handle) {
@@ -2808,13 +2808,13 @@
         },
 
         // Drag the whole mind map with your mouse, when it's larger that the container
-        _drag_nodes: function () {
+        enable_draggable_canvas: function () {
             // If draggable option is true.
             if (this.opts.draggable) {
                 // Dragging disabled by default.
                 let dragging = false
                 let x, y
-                if (this.opts.hide_scrollbars) {
+                if (this.opts.hide_scrollbars_when_draggable) {
                     // Avoid scrollbars when mind map is larger than the container (e_panel = id jsmind-inner)
                     this.e_panel.style = 'overflow: hidden'
                 }

--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -54,14 +54,15 @@
         theme: null,
         mode: 'full',    // full or side
         support_html: true,
-        draggable: false, // drag the mind map with your mouse, when it's larger that the container
 
         view: {
             engine: 'canvas',
             hmargin: 100,
             vmargin: 50,
             line_width: 2,
-            line_color: '#555'
+            line_color: '#555',
+            draggable: false, // drag the mind map with your mouse, when it's larger that the container
+            hide_scrollbars: false // hide container scrollbars, when mind map is larger than container and draggable option is true.
         },
         layout: {
             hspace: 30,
@@ -1084,7 +1085,9 @@
                 hmargin: opts.view.hmargin,
                 vmargin: opts.view.vmargin,
                 line_width: opts.view.line_width,
-                line_color: opts.view.line_color
+                line_color: opts.view.line_color,
+                draggable: opts.view.draggable,
+                hide_scrollbars: opts.view.hide_scrollbars
             };
             // create instance of function provider
             this.data = new jm.data_provider(this);
@@ -1100,8 +1103,6 @@
             this._event_bind();
 
             jm.init_plugins(this);
-
-            this._drag_nodes()
         },
 
         enable_edit: function () {
@@ -1670,31 +1671,6 @@
                 this.event_handles[i](type, data);
             }
         },
-
-        // Drag the whole mind map with your mouse, when it's larger that the container
-        _drag_nodes: function () {
-            if (this.options.draggable) {
-                // Avoid scrollbars when mind map is larger than the container (e_panel = jsmind-inner)
-                this.view.e_panel.style = 'overflow: hidden'
-                // Move the whole mind map with mouse moves, while button is down.
-                this.view.container.onmousedown = (eventDown) => {
-                    // Record current mouse position.
-                    let x = eventDown.clientX
-                    let y = eventDown.clientY
-                    // Stop moving mind map once mouse button is released.
-                    this.view.container.onmouseup = () => {
-                        this.view.container.onmousemove = null
-                    }
-                    // Follow current mouse position and move mind map accordingly.
-                    this.view.container.onmousemove = (eventMove) => {
-                        this.view.e_panel.scrollBy(x - eventMove.clientX, y - eventMove.clientY)
-                        // Record new current position.
-                        x = eventMove.clientX
-                        y = eventMove.clientY
-                    }
-                }
-            }
-        }
 
     };
 
@@ -2365,6 +2341,8 @@
             });
 
             this.container.appendChild(this.e_panel);
+
+            this._drag_nodes()
         },
 
         add_event: function (obj, event_name, event_handle) {
@@ -2828,6 +2806,40 @@
                 this.graph.draw_line(pout, pin, _offset);
             }
         },
+
+        // Drag the whole mind map with your mouse, when it's larger that the container
+        _drag_nodes: function () {
+            if (this.opts.draggable) {
+                // Dragging disabled by default.
+                let dragging = false
+                let x, y
+                if (this.opts.hide_scrollbars) {
+                    // Avoid scrollbars when mind map is larger than the container (e_panel = id jsmind-inner)
+                    this.e_panel.style = 'overflow: hidden'
+                }
+                // Move the whole mind map with mouse moves, while button is down.
+                jm.util.dom.add_event(this.container, 'mousedown', (eventDown) => {
+                    dragging = true
+                    // Record current mouse position.
+                    x = eventDown.clientX
+                    y = eventDown.clientY
+                })
+                // Stop moving mind map once mouse button is released.
+                jm.util.dom.add_event(this.container, 'mouseup', () => {
+                    dragging = false
+                })
+                // Follow current mouse position and move mind map accordingly.
+                jm.util.dom.add_event(this.container, 'mousemove', (eventMove) => {
+                    if (dragging) {
+                        this.e_panel.scrollBy(x - eventMove.clientX, y - eventMove.clientY)
+                        // Record new current position.
+                        x = eventMove.clientX
+                        y = eventMove.clientY
+                    }
+                })
+            }
+        },
+
     };
 
     // shortcut provider

--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -2809,6 +2809,7 @@
 
         // Drag the whole mind map with your mouse, when it's larger that the container
         _drag_nodes: function () {
+            // If draggable option is true.
             if (this.opts.draggable) {
                 // Dragging disabled by default.
                 let dragging = false

--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -1678,7 +1678,7 @@
                 this.view.e_panel.style = 'overflow: hidden'
                 // Move the whole mind map with mouse moves, while button is down.
                 this.view.container.onmousedown = (eventDown) => {
-                    // Record initial mouse position.
+                    // Record current mouse position.
                     let x = eventDown.clientX
                     let y = eventDown.clientY
                     // Stop moving mind map once mouse button is released.
@@ -1688,7 +1688,7 @@
                     // Follow current mouse position and move mind map accordingly.
                     this.view.container.onmousemove = (eventMove) => {
                         this.view.e_panel.scrollBy(x - eventMove.clientX, y - eventMove.clientY)
-                        // Record new reference position.
+                        // Record new current position.
                         x = eventMove.clientX
                         y = eventMove.clientY
                     }


### PR DESCRIPTION
Adding "draggable" option and corresponding "_drag_nodes" function, to override default behavior in case the mind map is bigger than the container.
If true, no vertical nor horizontal scrollbars will appear, instead the whole mind map will be draggable while mouse button is down.