### PR TITLE
hide screenshot canvas, resolve #364

### DIFF
--- a/style/jsmind.css
+++ b/style/jsmind.css
@@ -24,6 +24,10 @@
     user-select: none;
 }
 
+.jsmind-inner canvas {
+    position: absolute;
+}
+
 /* z-index:1 */
 svg.jsmind {
     position: absolute;


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

bug fix #364 :

given `position: absolute` to the  screenshot `canvas`, so that it won't inflate the parent element.


<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
