### PR TITLE
[Feature] allow string direction

### DIFF
--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -115,7 +115,25 @@
     };
 
     // ============= static object =============================================
-    jm.direction = { left: -1, center: 0, right: 1 };
+    jm.direction = {
+        left: -1, center: 0, right: 1, of: function (dir) {
+            if (!dir || dir === -1 || dir === 0 || dir === 1) {
+                return dir;
+            }
+            if (dir === '-1' || dir === '0' || dir === '1') {
+                return parseInt(dir);
+            }
+            if (dir.toLowerCase() === 'left') {
+                return this.left;
+            }
+            if (dir.toLowerCase() === 'right') {
+                return this.right;
+            }
+            if (dir.toLowerCase() === 'center') {
+                return this.center;
+            }
+        }
+    };
     jm.event_type = { show: 1, resize: 2, edit: 3, select: 4 };
     jm.key = { meta: 1 << 13, ctrl: 1 << 12, alt: 1 << 11, shift: 1 << 10 };
 
@@ -1291,7 +1309,10 @@
         add_node: function (parent_node, nodeid, topic, data, direction) {
             if (this.get_editable()) {
                 var the_parent_node = this.get_node(parent_node);
-                var dir = direction || this.layout.calculate_next_child_direction(the_parent_node);
+                var dir = jm.direction.of(direction)
+                if (dir === undefined) {
+                    dir = this.layout.calculate_next_child_direction(the_parent_node);
+                }
                 var node = this.mind.add_node(the_parent_node, nodeid, topic, data, dir);
                 if (!!node) {
                     this.view.add_node(node);
@@ -1311,7 +1332,10 @@
         insert_node_before: function (node_before, nodeid, topic, data, direction) {
             if (this.get_editable()) {
                 var the_node_before = this.get_node(node_before);
-                var dir = direction || this.layout.calculate_next_child_direction(the_node_before.parent);
+                var dir = jm.direction.of(direction)
+                if (dir === undefined) {
+                    dir = this.layout.calculate_next_child_direction(the_node_before.parent);
+                }
                 var node = this.mind.insert_node_before(the_node_before, nodeid, topic, data, dir);
                 if (!!node) {
                     this.view.add_node(node);
@@ -1329,7 +1353,10 @@
         insert_node_after: function (node_after, nodeid, topic, data, direction) {
             if (this.get_editable()) {
                 var the_node_after = this.get_node(node_after);
-                var dir = direction || this.layout.calculate_next_child_direction(the_node_after.parent);
+                var dir = jm.direction.of(direction)
+                if (dir === undefined) {
+                    dir = this.layout.calculate_next_child_direction(the_node_after.parent);
+                }
                 var node = this.mind.insert_node_after(the_node_after, nodeid, topic, data, dir);
                 if (!!node) {
                     this.view.add_node(node);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "jsmind",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsmind",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "description": "jsMind is a pure javascript library for mindmap, it base on html5 canvas. jsMind was released under BSD license, you can embed it in any project, if only you observe the license.",
     "main": "js/jsmind.js",
     "directories": {

--- a/src/jsmind.common.js
+++ b/src/jsmind.common.js
@@ -15,7 +15,25 @@ if (typeof String.prototype.startsWith != 'function') {
     };
 }
 
-export const Direction = { left: -1, center: 0, right: 1 };
+export const Direction = {
+    left: -1, center: 0, right: 1, of: function (dir) {
+        if (!dir || dir === -1 || dir === 0 || dir === 1) {
+            return dir;
+        }
+        if (dir === '-1' || dir === '0' || dir === '1') {
+            return parseInt(dir);
+        }
+        if (dir.toLowerCase() === 'left') {
+            return this.left;
+        }
+        if (dir.toLowerCase() === 'right') {
+            return this.right;
+        }
+        if (dir.toLowerCase() === 'center') {
+            return this.center;
+        }
+    }
+};
 export const EventType = { show: 1, resize: 2, edit: 3, select: 4 };
 export const Key = { meta: 1 << 13, ctrl: 1 << 12, alt: 1 << 11, shift: 1 << 10 };
 export const LogLevel = { debug: 1, info: 2, warn: 3, error: 4, disable: 9 };

--- a/src/jsmind.common.js
+++ b/src/jsmind.common.js
@@ -16,7 +16,10 @@ if (typeof String.prototype.startsWith != 'function') {
 }
 
 export const Direction = {
-    left: -1, center: 0, right: 1, of: function (dir) {
+    left: -1,
+    center: 0,
+    right: 1,
+    of: function (dir) {
         if (!dir || dir === -1 || dir === 0 || dir === 1) {
             return dir;
         }
@@ -32,7 +35,7 @@ export const Direction = {
         if (dir.toLowerCase() === 'center') {
             return this.center;
         }
-    }
+    },
 };
 export const EventType = { show: 1, resize: 2, edit: 3, select: 4 };
 export const Key = { meta: 1 << 13, ctrl: 1 << 12, alt: 1 << 11, shift: 1 << 10 };

--- a/src/jsmind.js
+++ b/src/jsmind.js
@@ -315,7 +315,7 @@ export default class jsMind {
     add_node(parent_node, node_id, topic, data, direction) {
         if (this.get_editable()) {
             var the_parent_node = this.get_node(parent_node);
-            var dir = Direction.of(direction)
+            var dir = Direction.of(direction);
             if (dir === undefined) {
                 dir = this.layout.calculate_next_child_direction(the_parent_node);
             }
@@ -341,7 +341,7 @@ export default class jsMind {
     insert_node_before(node_before, node_id, topic, data, direction) {
         if (this.get_editable()) {
             var the_node_before = this.get_node(node_before);
-            var dir = Direction.of(direction)
+            var dir = Direction.of(direction);
             if (dir === undefined) {
                 dir = this.layout.calculate_next_child_direction(the_node_before.parent);
             }
@@ -365,7 +365,7 @@ export default class jsMind {
     insert_node_after(node_after, node_id, topic, data, direction) {
         if (this.get_editable()) {
             var the_node_after = this.get_node(node_after);
-            var dir = Direction.of(direction)
+            var dir = Direction.of(direction);
             if (dir === undefined) {
                 dir = this.layout.calculate_next_child_direction(the_node_after.parent);
             }

--- a/src/jsmind.js
+++ b/src/jsmind.js
@@ -315,7 +315,10 @@ export default class jsMind {
     add_node(parent_node, node_id, topic, data, direction) {
         if (this.get_editable()) {
             var the_parent_node = this.get_node(parent_node);
-            var dir = direction || this.layout.calculate_next_child_direction(the_parent_node);
+            var dir = Direction.of(direction)
+            if (dir === undefined) {
+                dir = this.layout.calculate_next_child_direction(the_parent_node);
+            }
             var node = this.mind.add_node(the_parent_node, node_id, topic, data, dir);
             if (!!node) {
                 this.view.add_node(node);
@@ -338,8 +341,10 @@ export default class jsMind {
     insert_node_before(node_before, node_id, topic, data, direction) {
         if (this.get_editable()) {
             var the_node_before = this.get_node(node_before);
-            var dir =
-                direction || this.layout.calculate_next_child_direction(the_node_before.parent);
+            var dir = Direction.of(direction)
+            if (dir === undefined) {
+                dir = this.layout.calculate_next_child_direction(the_node_before.parent);
+            }
             var node = this.mind.insert_node_before(the_node_before, node_id, topic, data, dir);
             if (!!node) {
                 this.view.add_node(node);
@@ -360,8 +365,10 @@ export default class jsMind {
     insert_node_after(node_after, node_id, topic, data, direction) {
         if (this.get_editable()) {
             var the_node_after = this.get_node(node_after);
-            var dir =
-                direction || this.layout.calculate_next_child_direction(the_node_after.parent);
+            var dir = Direction.of(direction)
+            if (dir === undefined) {
+                dir = this.layout.calculate_next_child_direction(the_node_after.parent);
+            }
             var node = this.mind.insert_node_after(the_node_after, node_id, topic, data, dir);
             if (!!node) {
                 this.view.add_node(node);


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

allow to use `'left'`/`'right'` on `add_node`/`insert_node_before`/`insert_node_after`. So they will be all right

```
jm.add_node(node, id, topic, {}, 'left')
jm.add_node(node, id, topic, {}, jsMind.direction.left)
jm.add_node(node, id, topic, {}, -1)
```

resolve https://github.com/hizzgdev/jsmind/issues/426
the feature is included in 0.5.4

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
