### PR TITLE
allow zoom mindmap out of mouse event handler

### DIFF
--- a/src/jsmind.view_provider.js
+++ b/src/jsmind.view_provider.js
@@ -350,11 +350,11 @@ export class ViewProvider {
             return false;
         }
         let e_panel_rect = this.e_panel.getBoundingClientRect();
-        let mouse_offset = { x: e.x - e_panel_rect.x, y: e.y - e_panel_rect.y };
+        let zoom_center = !!e ? { x: e.x - e_panel_rect.x, y: e.y - e_panel_rect.y } : { x: e_panel_rect.width / 2, y: e_panel_rect.height / 2 }
         let panel_scroll_x =
-            ((this.e_panel.scrollLeft + mouse_offset.x) * zoom) / this.actualZoom - mouse_offset.x;
+            ((this.e_panel.scrollLeft + zoom_center.x) * zoom) / this.actualZoom - zoom_center.x;
         let panel_scroll_y =
-            ((this.e_panel.scrollTop + mouse_offset.y) * zoom) / this.actualZoom - mouse_offset.y;
+            ((this.e_panel.scrollTop + zoom_center.y) * zoom) / this.actualZoom - zoom_center.y;
 
         this.actualZoom = zoom;
         for (var i = 0; i < this.e_panel.children.length; i++) {

--- a/src/jsmind.view_provider.js
+++ b/src/jsmind.view_provider.js
@@ -350,7 +350,9 @@ export class ViewProvider {
             return false;
         }
         let e_panel_rect = this.e_panel.getBoundingClientRect();
-        let zoom_center = !!e ? { x: e.x - e_panel_rect.x, y: e.y - e_panel_rect.y } : { x: e_panel_rect.width / 2, y: e_panel_rect.height / 2 }
+        let zoom_center = !!e
+            ? { x: e.x - e_panel_rect.x, y: e.y - e_panel_rect.y }
+            : { x: e_panel_rect.width / 2, y: e_panel_rect.height / 2 };
         let panel_scroll_x =
             ((this.e_panel.scrollLeft + zoom_center.x) * zoom) / this.actualZoom - zoom_center.x;
         let panel_scroll_y =


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

The dom event is not required by `zoom` function now.
The mindmap will zoom with mindmap center as the zoom center by default.

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
