### PR TITLE
Add Latex feature

### DIFF
--- a/example/1_basic.html
+++ b/example/1_basic.html
@@ -10,7 +10,11 @@
             href="//cdn.jsdelivr.net/npm/jsmind/style/jsmind.css"
         />
         <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-        <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+        <script
+            id="MathJax-script"
+            async
+            src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+        ></script>
         <style type="text/css">
             #jsmind_container {
                 width: 800px;

--- a/example/1_basic.html
+++ b/example/1_basic.html
@@ -9,6 +9,8 @@
             rel="stylesheet"
             href="//cdn.jsdelivr.net/npm/jsmind/style/jsmind.css"
         />
+        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+        <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
         <style type="text/css">
             #jsmind_container {
                 width: 800px;
@@ -71,6 +73,7 @@
                 // var mind_data = jm.get_data();
                 // alert(mind_data);
                 jm.add_node('sub2', 'sub23', 'new node', { 'background-color': 'red' });
+                jm.add_node('sub2', 'sub24', '$$x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}$$');
                 jm.set_node_color('sub21', 'green', '#ccc');
             }
 

--- a/js/jsmind.js
+++ b/js/jsmind.js
@@ -145,7 +145,7 @@
         if (typeof bExpanded === 'undefined') { bExpanded = true; }
         this.id = sId;
         this.index = iIndex;
-        this.topic = sTopic;
+        this.topic = this.formatText(sTopic);
         this.data = oData || {};
         this.isroot = bIsRoot;
         this.parent = oParent;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "jsmind",
             "version": "0.6.4",
             "license": "BSD-3-Clause",
+            "dependencies": {
+                "katex": "^0.16.8"
+            },
             "devDependencies": {
                 "http-server": "^14.1.1",
                 "jest": "^28.1.0",
@@ -3126,6 +3129,29 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/katex": {
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.8.tgz",
+            "integrity": "sha512-ftuDnJbcbOckGY11OO+zg3OofESlbR5DRl2cmN8HeWeeFIV7wTXvAOx8kEjZjobhA+9wh2fbKeO6cdcA9Mnovg==",
+            "funding": [
+                "https://opencollective.com/katex",
+                "https://github.com/sponsors/katex"
+            ],
+            "dependencies": {
+                "commander": "^8.3.0"
+            },
+            "bin": {
+                "katex": "cli.js"
+            }
+        },
+        "node_modules/katex/node_modules/commander": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/kleur": {
@@ -6916,6 +6942,21 @@
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true
+        },
+        "katex": {
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.8.tgz",
+            "integrity": "sha512-ftuDnJbcbOckGY11OO+zg3OofESlbR5DRl2cmN8HeWeeFIV7wTXvAOx8kEjZjobhA+9wh2fbKeO6cdcA9Mnovg==",
+            "requires": {
+                "commander": "^8.3.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "8.3.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+                    "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+                }
+            }
         },
         "kleur": {
             "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "jest": {
         "verbose": true,
         "testEnvironment": "jsdom"
+    },
+    "dependencies": {
+        "katex": "^0.16.8"
     }
 }

--- a/src/jsmind.js
+++ b/src/jsmind.js
@@ -440,7 +440,7 @@ export default class jsMind {
                     this.view.update_node(node);
                     return;
                 }
-                node.topic = topic;
+                node.topic = node.formatText(topic);
                 this.view.update_node(node);
                 this.layout.layout();
                 this.view.show(false);

--- a/src/jsmind.node.js
+++ b/src/jsmind.node.js
@@ -22,7 +22,7 @@ export class Node {
         }
         this.id = sId;
         this.index = iIndex;
-        this.topic = sTopic;
+        this.topic = this.formatText(sTopic);
         this.data = oData || {};
         this.isroot = bIsRoot;
         this.parent = oParent;
@@ -45,6 +45,21 @@ export class Node {
             w: vd.width,
             h: vd.height,
         };
+    }
+    formatText(text) {
+        if (!text) {
+            return '';
+        }
+        // Check if the text is wrapped with $$, if it is, it's considered as LaTeX.
+        if (text.startsWith('$$') && text.endsWith('$$')) {
+            const latex = text.substring(2, text.length - 2);
+            // Use MathJax to convert LaTeX to HTML.
+
+            var text = MathJax.tex2svg(latex, {display: false}).outerHTML;
+            logger.log("MathJax",text)
+            return text
+        }
+        return text;
     }
 
     static compare(node1, node2) {

--- a/src/jsmind.node.js
+++ b/src/jsmind.node.js
@@ -55,9 +55,8 @@ export class Node {
             const latex = text.substring(2, text.length - 2);
             // Use MathJax to convert LaTeX to HTML.
 
-            var text = MathJax.tex2svg(latex, {display: false}).outerHTML;
-            logger.log("MathJax",text)
-            return text
+            var text = MathJax.tex2svg(latex, { display: false }).outerHTML;
+            return text;
         }
         return text;
     }

--- a/src/jsmind.view_provider.js
+++ b/src/jsmind.view_provider.js
@@ -225,9 +225,10 @@ export class ViewProvider {
         var element = view_data.element;
         if (!!node.topic) {
             if (this.opts.support_html) {
-                $.h(element, node.topic);
+                $.h(element, node.formatText(topic));
+                MathJax.typesetPromise([element]);
             } else {
-                $.t(element, node.topic);
+                $.t(element, node.formatText(topic));
             }
         }
         if (this.layout.is_visible(node)) {

--- a/tests/unit/jsmind.test.js
+++ b/tests/unit/jsmind.test.js
@@ -2,7 +2,9 @@ import { describe, expect, test, jest, beforeAll } from '@jest/globals';
 import { __version__, logger, EventType } from '../../src/jsmind.common.js';
 import { $ } from '../../src/jsmind.dom.js';
 import jm from '../../src/jsmind.js';
-
+global.MathJax = {
+    typesetPromise: jest.fn(),
+};
 beforeAll(() => {
     $.c = jest.fn();
     $.g = jest.fn();
@@ -10,6 +12,9 @@ beforeAll(() => {
     logger.error = jest.fn();
     logger.warn = jest.fn();
     logger.debug = jest.fn();
+});
+afterEach(() => {
+    jest.clearAllMocks();
 });
 
 const mockElement = {


### PR DESCRIPTION
**Purpose:** I want to let the user be able to type Latex format function/equation in the node.
**How:**
Main Dependency: MathJax
Mainly I add the following function in the src/jsmind.node.js: 
```
formatText(text) {
        if (!text) {
            return '';
        }
        // Check if the text is wrapped with $$, if it is, it's considered as LaTeX.
        if (text.startsWith('$$') && text.endsWith('$$')) {
            const latex = text.substring(2, text.length - 2);
            // Use MathJax to convert LaTeX to HTML.

            var text = MathJax.tex2svg(latex, { display: false }).outerHTML;
            return text;
        }
        return text;
    }
```
And change the original `this.topic = sTopic` to `this.topic = this.formatText(sTopic);`
**Result:**
Although I passed the test, but there are still some warnings, and I only realized showing the Latex-format text in first render, but after drag or edit, the Latex-format cannot be shown. I wonder whether it is due to the page is not correctly rerendered.
I am happy to discuss this with you guys.