### PR TITLE
fix: plugin duplication error

### DIFF
--- a/src/jsmind.plugin.js
+++ b/src/jsmind.plugin.js
@@ -16,10 +16,9 @@ export function register(plugin) {
     if (!(plugin instanceof Plugin)) {
         throw new Error('can not register plugin, it is not an instance of Plugin');
     }
-    if (plugin_data.plugins.map(p => p.name).includes(plugin.name)) {
-        throw new Error('can not register plugin ' + plugin.name + ': plugin name already exist');
+    if (!plugin_data.plugins.map(p => p.name).includes(plugin.name)) { 
+        plugin_data.plugins.push(plugin); 
     }
-    plugin_data.plugins.push(plugin);
 }
 
 export function apply(jm, options) {


### PR DESCRIPTION
Right now, when I try to add more than two iframes with jsmind and draggable plugin, cnds break because the draggable plugin was loaded and threw an error. With this fix, it will only add a plugin that has not been added yet

Issue related: https://github.com/hizzgdev/jsmind/issues/503