### PR TITLE
fix bug: draggable-node plugin block dblclick to trigger the edit mode

### DIFF
--- a/src/plugins/jsmind.draggable-node.js
+++ b/src/plugins/jsmind.draggable-node.js
@@ -273,7 +273,9 @@ class DraggableNode {
                         jd.lookup_close_node.call(jd);
                     }, jd.options.lookup_interval);
                 }, this.options.lookup_delay);
-                this.capture = true;
+                $.w.setTimeout(function () {
+                    jd.capture = true;
+                }, 0);
             }
         }
     }


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

It's found that, the double-click event is broken by the `this.capture = true` in the `draggabe-node` plugin, in specific versions of OS and browsers.

Resolve https://github.com/hizzgdev/jsmind/issues/471 .

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
