### PR TITLE
fix bug: draggable-node plugin block dblclick to trigger the edit mode

### DIFF
--- a/src/plugins/jsmind.draggable-node.js
+++ b/src/plugins/jsmind.draggable-node.js
@@ -26,6 +26,7 @@ const clear_selection =
 const DEFAULT_OPTIONS = {
     line_width: 5,
     line_color: 'rgba(0,0,0,0.3)',
+    drag_start_delay: 100,
     lookup_delay: 500,
     lookup_interval: 80,
     scrolling_trigger_width: 20,
@@ -55,6 +56,7 @@ class DraggableNode {
         this.offset_y = 0;
         this.hlookup_delay = 0;
         this.hlookup_timer = 0;
+        this.hdrag_start_delay = 0;
         this.capture = false;
         this.moved = false;
         this.canvas_draggable = jm.get_view_draggable();
@@ -206,7 +208,10 @@ class DraggableNode {
         var container = this.jm.view.container;
         $.on(container, 'mousedown', function (e) {
             var evt = e || event;
-            jd.dragstart.call(jd, evt);
+            jd.hdrag_start_delay = $.w.setTimeout(function () {
+                jd.hdrag_start_delay = 0;
+                jd.dragstart.call(jd, evt);
+            }, jd.options.drag_start_delay);
         });
         $.on(container, 'mousemove', function (e) {
             var evt = e || event;
@@ -214,11 +219,18 @@ class DraggableNode {
         });
         $.on(container, 'mouseup', function (e) {
             var evt = e || event;
+            if (jd.hdrag_start_delay != 0) {
+                $.w.clearTimeout(jd.hdrag_start_delay);
+                jd.hdrag_start_delay = 0;
+            }
             jd.dragend.call(jd, evt);
         });
         $.on(container, 'touchstart', function (e) {
             var evt = e || event;
-            jd.dragstart.call(jd, evt);
+            jd.hdrag_start_delay = $.w.setTimeout(function () {
+                jd.hdrag_start_delay = 0;
+                jd.dragstart.call(jd, evt);
+            }, jd.options.drag_start_delay);
         });
         $.on(container, 'touchmove', function (e) {
             var evt = e || event;
@@ -226,6 +238,10 @@ class DraggableNode {
         });
         $.on(container, 'touchend', function (e) {
             var evt = e || event;
+            if (jd.hdrag_start_delay != 0) {
+                $.w.clearTimeout(jd.hdrag_start_delay);
+                jd.hdrag_start_delay = 0;
+            }
             jd.dragend.call(jd, evt);
         });
     }
@@ -273,9 +289,7 @@ class DraggableNode {
                         jd.lookup_close_node.call(jd);
                     }, jd.options.lookup_interval);
                 }, this.options.lookup_delay);
-                $.w.setTimeout(function () {
-                    jd.capture = true;
-                }, 0);
+                jd.capture = true;
             }
         }
     }


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

revert https://github.com/hizzgdev/jsmind/pull/509 and resolve https://github.com/hizzgdev/jsmind/issues/471

It's found that an additionally `mousemove` event is trigger while double click on touchpad in specific versions of OS and browsers. the `mousemove` changes the event.target, causing the node to be edited not to be detected.

Add a delay to start drag to avoid the issue.

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
