### PR TITLE
re-fix bug: draggalbe-node plugin block double click unexpected

### DIFF
--- a/src/plugins/jsmind.draggable-node.js
+++ b/src/plugins/jsmind.draggable-node.js
@@ -26,7 +26,6 @@ const clear_selection =
 const DEFAULT_OPTIONS = {
     line_width: 5,
     line_color: 'rgba(0,0,0,0.3)',
-    drag_start_delay: 100,
     lookup_delay: 500,
     lookup_interval: 80,
     scrolling_trigger_width: 20,
@@ -56,7 +55,6 @@ class DraggableNode {
         this.offset_y = 0;
         this.hlookup_delay = 0;
         this.hlookup_timer = 0;
-        this.hdrag_start_delay = 0;
         this.capture = false;
         this.moved = false;
         this.canvas_draggable = jm.get_view_draggable();
@@ -208,29 +206,21 @@ class DraggableNode {
         var container = this.jm.view.container;
         $.on(container, 'mousedown', function (e) {
             var evt = e || event;
-            jd.hdrag_start_delay = $.w.setTimeout(function () {
-                jd.hdrag_start_delay = 0;
-                jd.dragstart.call(jd, evt);
-            }, jd.options.drag_start_delay);
+            jd.dragstart.call(jd, evt);
         });
         $.on(container, 'mousemove', function (e) {
             var evt = e || event;
-            jd.drag.call(jd, evt);
+            if (e.movementX > 0 || e.movementY > 0) {
+                jd.drag.call(jd, evt);
+            }
         });
         $.on(container, 'mouseup', function (e) {
             var evt = e || event;
-            if (jd.hdrag_start_delay != 0) {
-                $.w.clearTimeout(jd.hdrag_start_delay);
-                jd.hdrag_start_delay = 0;
-            }
             jd.dragend.call(jd, evt);
         });
         $.on(container, 'touchstart', function (e) {
             var evt = e || event;
-            jd.hdrag_start_delay = $.w.setTimeout(function () {
-                jd.hdrag_start_delay = 0;
-                jd.dragstart.call(jd, evt);
-            }, jd.options.drag_start_delay);
+            jd.dragstart.call(jd, evt);
         });
         $.on(container, 'touchmove', function (e) {
             var evt = e || event;
@@ -238,10 +228,6 @@ class DraggableNode {
         });
         $.on(container, 'touchend', function (e) {
             var evt = e || event;
-            if (jd.hdrag_start_delay != 0) {
-                $.w.clearTimeout(jd.hdrag_start_delay);
-                jd.hdrag_start_delay = 0;
-            }
             jd.dragend.call(jd, evt);
         });
     }


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

Since the root cause is the unexpected `mousemove` event, we can add a condition to avoid it instead of delay trigger (https://github.com/hizzgdev/jsmind/pull/511).

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
