### PR TITLE
dragging is only triggered when the left button is pressed

### DIFF
--- a/src/plugins/jsmind.draggable-node.js
+++ b/src/plugins/jsmind.draggable-node.js
@@ -206,7 +206,9 @@ class DraggableNode {
         var container = this.jm.view.container;
         $.on(container, 'mousedown', function (e) {
             var evt = e || event;
-            jd.dragstart.call(jd, evt);
+            if (evt.button === 0) {
+                jd.dragstart.call(jd, evt);
+            }
         });
         $.on(container, 'mousemove', function (e) {
             var evt = e || event;


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

It's found that `drag_start` is called on right click, this PR avoid the behavior.

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
