### PR TITLE
add new option custom_node_render to support vary rendering logic

### DIFF
--- a/src/jsmind.js
+++ b/src/jsmind.js
@@ -65,6 +65,7 @@ export default class jsMind {
             hide_scrollbars_when_draggable: this.options.view.hide_scrollbars_when_draggable,
             node_overflow: this.options.view.node_overflow,
             zoom: this.options.view.zoom,
+            custom_node_render: this.options.view.custom_node_render,
         };
         // create instance of function provider
         this.data = new DataProvider(this);

--- a/src/jsmind.option.js
+++ b/src/jsmind.option.js
@@ -31,7 +31,7 @@ const default_options = {
             max: 2.1,
             step: 0.1,
         },
-        custom_node_render: null
+        custom_node_render: null,
     },
     layout: {
         hspace: 30,

--- a/src/jsmind.option.js
+++ b/src/jsmind.option.js
@@ -31,6 +31,7 @@ const default_options = {
             max: 2.1,
             step: 0.1,
         },
+        custom_node_render: null
     },
     layout: {
         hspace: 30,

--- a/src/jsmind.view_provider.js
+++ b/src/jsmind.view_provider.js
@@ -26,6 +26,7 @@ export class ViewProvider {
         this.editing_node = null;
 
         this.graph = null;
+        this.render_node = !!options.custom_node_render ? this._custom_node_render : this._default_node_render;
         this._initialized = false;
     }
     init() {
@@ -185,11 +186,7 @@ export class ViewProvider {
             view_data.expander = d_e;
         }
         if (!!node.topic) {
-            if (this.opts.support_html) {
-                $.h(d, node.topic);
-            } else {
-                $.t(d, node.topic);
-            }
+            this.render_node(d, node);
         }
         d.setAttribute('nodeid', node.id);
         d.style.visibility = 'hidden';
@@ -224,11 +221,7 @@ export class ViewProvider {
         var view_data = node._data.view;
         var element = view_data.element;
         if (!!node.topic) {
-            if (this.opts.support_html) {
-                $.h(element, node.topic);
-            } else {
-                $.t(element, node.topic);
-            }
+            this.render_node(element, node);
         }
         if (this.layout.is_visible(node)) {
             view_data.width = element.clientWidth;
@@ -297,11 +290,7 @@ export class ViewProvider {
             element.style.zIndex = 'auto';
             element.removeChild(this.e_editor);
             if (util.text.is_empty(topic) || node.topic === topic) {
-                if (this.opts.support_html) {
-                    $.h(element, node.topic);
-                } else {
-                    $.t(element, node.topic);
-                }
+                this.render_node(element, node)
             } else {
                 this.jm.update_node(node.id, topic);
             }
@@ -446,6 +435,19 @@ export class ViewProvider {
                 expander.style.display = 'none';
                 expander.style.visibility = 'hidden';
             }
+        }
+    }
+    _default_node_render(ele, node) {
+        if (this.opts.support_html) {
+            $.h(ele, node.topic);
+        } else {
+            $.t(ele, node.topic);
+        }
+    }
+    _custom_node_render(ele, node) {
+        let rendered = this.opts.custom_node_render(this.jm, ele, node);
+        if (!rendered) {
+            this._default_node_render(ele, node);
         }
     }
     reset_node_custom_style(node) {

--- a/src/jsmind.view_provider.js
+++ b/src/jsmind.view_provider.js
@@ -26,7 +26,9 @@ export class ViewProvider {
         this.editing_node = null;
 
         this.graph = null;
-        this.render_node = !!options.custom_node_render ? this._custom_node_render : this._default_node_render;
+        this.render_node = !!options.custom_node_render
+            ? this._custom_node_render
+            : this._default_node_render;
         this._initialized = false;
     }
     init() {
@@ -290,7 +292,7 @@ export class ViewProvider {
             element.style.zIndex = 'auto';
             element.removeChild(this.e_editor);
             if (util.text.is_empty(topic) || node.topic === topic) {
-                this.render_node(element, node)
+                this.render_node(element, node);
             } else {
                 this.jm.update_node(node.id, topic);
             }


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

Add new option `custom_node_render` to support vary rendering logic.

Now, It's possible to customize your rendering logic for specific node.

```javascript
let options = {
    ...
    view: {
        custom_node_render: function (jm, element, node) {
            // any customized logic
            let updatedTopic = '<img src="">'+node.topic;
            element.innerHTML = updatedTopic;
            // return true to tell jsMind the node has been rendered
            return true;
        }
    }
}
```


<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
