### PR TITLE
[Bugfix] fix bug that the screenshot is broken when jsmind is zoomed

### DIFF
--- a/src/plugins/jsmind.screenshot.js
+++ b/src/plugins/jsmind.screenshot.js
@@ -53,6 +53,7 @@ class JmScreenshot {
         let c = $.c('canvas');
         c.width = this.jm.view.size.w;
         c.height = this.jm.view.size.h;
+        c.style.visibility = 'hidden';
         this.jm.view.e_panel.appendChild(c);
         return c;
     }
@@ -73,7 +74,7 @@ class JmScreenshot {
 
     draw_nodes(ctx) {
         return domtoimage
-            .toSvg(this.jm.view.e_nodes)
+            .toSvg(this.jm.view.e_nodes, { style: { zoom: 1 } })
             .then(this.load_image)
             .then(function (img) {
                 ctx.drawImage(img, 0, 0);


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

An issue has been confirmed where the screenshot feature is broken when zooming. which is reported in https://github.com/hizzgdev/jsmind/issues/552.

This PR fix the issue, and will resolve #552.

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
