### PR TITLE
[Bugfix] update index after remove node

### DIFF
--- a/src/jsmind.mind.js
+++ b/src/jsmind.mind.js
@@ -219,8 +219,9 @@ export class Mind {
         }
         // clean all children
         children.length = 0;
+        var node_parent = node.parent;
         // remove from parent's children
-        var sibling = node.parent.children;
+        var sibling = node_parent.children;
         var si = sibling.length;
         while (si--) {
             if (sibling[si].id == node.id) {
@@ -236,7 +237,7 @@ export class Mind {
         }
         // remove it's self
         node = null;
-        //delete node;
+        this._update_index(node_parent);
         return true;
     }
     _put_node(node) {


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

An issue has been confirmed where the `find_node_after` and `find_node_before` works unexpected after nodes are removed, which is reported in https://github.com/hizzgdev/jsmind/issues/551.

The api `find_node_after` and `find_node_before` relies on the continuity of `index` field of nodes. But the index of nodes are not updated after nodes are removed.

This PR update the nodes' index, and resolve #551.

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
