### PR TITLE
[Bugfix] zoom doesn't work when zoom < 1 and container size is changed bigger

### DIFF
--- a/src/jsmind.view_provider.js
+++ b/src/jsmind.view_provider.js
@@ -365,7 +365,8 @@ export class ViewProvider {
         }
         let e_panel_rect = this.e_panel.getBoundingClientRect();
         if (
-            zoom < 1 && zoom < this.zoom_current &&
+            zoom < 1 &&
+            zoom < this.zoom_current &&
             this.size.w * zoom < e_panel_rect.width &&
             this.size.h * zoom < e_panel_rect.height
         ) {

--- a/src/jsmind.view_provider.js
+++ b/src/jsmind.view_provider.js
@@ -365,7 +365,7 @@ export class ViewProvider {
         }
         let e_panel_rect = this.e_panel.getBoundingClientRect();
         if (
-            zoom < 1 &&
+            zoom < 1 && zoom < this.zoom_current &&
             this.size.w * zoom < e_panel_rect.width &&
             this.size.h * zoom < e_panel_rect.height
         ) {


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

It's confirmed that `zoom` doesn't work when `zoom < 1` and the container is changed bigger.
This PR fix the bug. It's a very small fix, will be included in the next version.

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
