### PR TITLE
fix bug that customized node can not be dragged

### DIFF
--- a/src/plugins/jsmind.draggable-node.js
+++ b/src/plugins/jsmind.draggable-node.js
@@ -167,8 +167,9 @@ class DraggableNode {
         this.view_draggable = this.jm.get_view_draggable();
 
         var jview = this.jm.view;
-        var el = e.target;
-        if (el.tagName.toLowerCase() != 'jmnode') {
+        var el = this.find_node_element(e.target);
+        if (!el) {
+            console.log('throw away');
             return;
         }
         if (this.view_draggable) {
@@ -284,6 +285,19 @@ class DraggableNode {
         this.view_panel_rect = null;
         this.moved = false;
         this.capture = false;
+    }
+    find_node_element(el) {
+        if (
+            el === this.jm.view.e_nodes ||
+            el === this.jm.view.e_panel ||
+            el === this.jm.view.container
+        ) {
+            return null;
+        }
+        if (el.tagName.toLowerCase() === 'jmnode') {
+            return el;
+        }
+        return this.find_node_element(el.parentNode);
     }
     lookup_target_node() {
         let sx = this.shadow.offsetLeft;


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

When a node is rendered by `custom_node_render`, and additional html element is added to the node, the node probably can not be dragged, because the target of the event is not `<jmnode...>` 

Fix https://github.com/hizzgdev/jsmind/issues/566 .

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
