### PR TITLE
[Bugfix] update index after node is moved to other parent

### DIFF
--- a/src/jsmind.mind.js
+++ b/src/jsmind.mind.js
@@ -181,8 +181,10 @@ export class Mind {
                         break;
                     }
                 }
+                let origin_parent = node.parent;
                 node.parent = parent_node;
                 parent_node.children.push(node);
+                this._update_index(origin_parent);
             }
 
             if (node.parent.isroot) {


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

An [issue 584](https://github.com/hizzgdev/jsmind/issues/584) has been confirmed that moving node up/down works unexpected after node is moved to other parent.

The root cause is same as https://github.com/hizzgdev/jsmind/pull/554, and the indexes of nodes in the original parent are not updated.

This PR update the nodes' index, and resolve the issue https://github.com/hizzgdev/jsmind/issues/584.


<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
