### PR TITLE
Feature support promised custom node render

### DIFF
--- a/src/jsmind.common.js
+++ b/src/jsmind.common.js
@@ -84,3 +84,22 @@ function setup_logger_level(log_level) {
         logger.error = console.error;
     }
 }
+
+// 如果 promise 不为空，则认为是 promise，执行 promise.then(follow_logic) 并返回新的 promise
+export function then_if_promise(promise, follow_logic) {
+    if (!!promise) {
+        return promise.then(() => {
+            follow_logic();
+        });
+    } else {
+        follow_logic();
+    }
+}
+
+export function is_promise(obj) {
+    return (
+        !!obj &&
+        (typeof obj === 'object' || typeof obj === 'function') &&
+        typeof obj.then === 'function'
+    );
+}

--- a/src/jsmind.js
+++ b/src/jsmind.js
@@ -335,22 +335,23 @@ export default class jsMind {
             }
             var node = this.mind.add_node(the_parent_node, node_id, topic, data, dir);
             if (!!node) {
-                this.view.add_node(node);
-                this.layout.layout();
-                this.view.show(false);
-                this.view.reset_node_custom_style(node);
-                this.expand_node(the_parent_node);
-                this.invoke_event_handle(EventType.edit, {
-                    evt: 'add_node',
-                    data: [the_parent_node.id, node_id, topic, data, dir],
-                    node: node_id,
+                return this.view.add_node(node).then(() => {
+                    this.layout.layout();
+                    this.view.show(false);
+                    this.view.reset_node_custom_style(node);
+                    this.expand_node(the_parent_node);
+                    this.invoke_event_handle(EventType.edit, {
+                        evt: 'add_node',
+                        data: [the_parent_node.id, node_id, topic, data, dir],
+                        node: node_id,
+                    });
+                    return node;
                 });
             }
-            return node;
         } else {
             logger.error('fail, this mind map is not editable');
-            return null;
         }
+        return Promise.resolve(null);
     }
     insert_node_before(node_before, node_id, topic, data, direction) {
         if (this.get_editable()) {
@@ -361,13 +362,14 @@ export default class jsMind {
             }
             var node = this.mind.insert_node_before(the_node_before, node_id, topic, data, dir);
             if (!!node) {
-                this.view.add_node(node);
-                this.layout.layout();
-                this.view.show(false);
-                this.invoke_event_handle(EventType.edit, {
-                    evt: 'insert_node_before',
-                    data: [the_node_before.id, node_id, topic, data, dir],
-                    node: node_id,
+                this.view.add_node(node).then(() => {
+                    this.layout.layout();
+                    this.view.show(false);
+                    this.invoke_event_handle(EventType.edit, {
+                        evt: 'insert_node_before',
+                        data: [the_node_before.id, node_id, topic, data, dir],
+                        node: node_id,
+                    });
                 });
             }
             return node;
@@ -385,13 +387,14 @@ export default class jsMind {
             }
             var node = this.mind.insert_node_after(the_node_after, node_id, topic, data, dir);
             if (!!node) {
-                this.view.add_node(node);
-                this.layout.layout();
-                this.view.show(false);
-                this.invoke_event_handle(EventType.edit, {
-                    evt: 'insert_node_after',
-                    data: [the_node_after.id, node_id, topic, data, dir],
-                    node: node_id,
+                this.view.add_node(node).then(() => {
+                    this.layout.layout();
+                    this.view.show(false);
+                    this.invoke_event_handle(EventType.edit, {
+                        evt: 'insert_node_after',
+                        data: [the_node_after.id, node_id, topic, data, dir],
+                        node: node_id,
+                    });
                 });
             }
             return node;

--- a/src/jsmind.js
+++ b/src/jsmind.js
@@ -444,11 +444,12 @@ export default class jsMind {
             }
             var node = this.get_node(node_id);
             if (!!node) {
-                if (node.topic === topic) {
-                    logger.info('nothing changed');
-                    this.view.update_node(node);
-                    return;
-                }
+                // 为了在 react 场景下，能通过编辑不修改退出这个场景，暂时注释掉下面代码
+                // if (node.topic === topic) {
+                //     logger.info('nothing changed');
+                //     this.view.update_node(node);
+                //     return;
+                // }
                 node.topic = topic;
                 const promise = this.view.update_node(node);
                 const follow_logic = () => {

--- a/src/jsmind.shortcut_provider.js
+++ b/src/jsmind.shortcut_provider.js
@@ -81,11 +81,12 @@ export class ShortcutProvider {
         var selected_node = _jm.get_selected_node();
         if (!!selected_node) {
             var node_id = this._newid();
-            var node = _jm.add_node(selected_node, node_id, 'New Node');
-            if (!!node) {
-                _jm.select_node(node_id);
-                _jm.begin_edit(node_id);
-            }
+            _jm.add_node(selected_node, node_id, 'New Node').then(node => {
+                if (!!node) {
+                    _jm.select_node(node_id);
+                    _jm.begin_edit(node_id);
+                }
+            });
         }
     }
     handle_addbrother(_jm, e) {


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

支持 custom_node_render 返回一个 promise，在 promise 的 then 中再执行所有后续动作。 
当 custom_node_render 的实现，是用 ReactDOM.render 等异步方式渲染的时候，若直接执行后续动作，因这时异步渲染还没有完成，会报很多错误。有了这个支持之后， 即可以通过 custom_node_render 接入 react 等异步组件库及其庞大生态了。

有几个说明：
1. 因为 DocumentFragment 的 render_node + parent.appendChild 的实现。 第一次 React 渲染组件时没有问题。第二次 React 渲染同样的 dom 时(update_node触发)会报错拒绝渲染：

Warning: render(...): It looks like the React-rendered content of this container was removed without using React. This is not supported and will cause errors. Instead, call ReactDOM.unmountComponentAtNode to empty a container.

因为 react 认为组件容器的内容被改过了。为了规避这个问题，在第二次异步渲染时，新建了一个 dom 节点替换原来的节点。

2. 将 jsmind 的一个优化的地方，就是编辑提交后， topic 没有修改时的短路逻辑删除了，和 topic 有修改时一样的处理。否则在 React 的场景总是会报错。

测试用例在单独的 react + jsmind 工程中： https://github.com/hqm19/jsmind-react

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
