### PR TITLE
fix bug: the editing node can be dragged

### DIFF
--- a/src/plugins/jsmind.draggable-node.js
+++ b/src/plugins/jsmind.draggable-node.js
@@ -163,10 +163,13 @@ class DraggableNode {
         if (this.capture) {
             return;
         }
+        var jview = this.jm.view;
+        if (jview.is_editing()) {
+            return;
+        }
         this.active_node = null;
         this.view_draggable = this.jm.get_view_draggable();
 
-        var jview = this.jm.view;
         var el = this.find_node_element(e.target);
         if (!el) {
             return;


### PR DESCRIPTION
<!--
请描述这个 pull-request 的目的，做法，以及修改的内容。
Please describe the proposal of your pull-request. why, how and what.
-->

It's reported by https://github.com/hizzgdev/jsmind/issues/622 that the editing node can be dragged, and the input element is included in the node instead of the node topic.

Actually a node in editing should not be dragged, because users are editing the content, the dragging probably be a misoperation. This PR disable the dragging while editing.

<!--
额外说明 | Additional notes

- 提交 pull-request 前，请确保其已经通过了你的测试，如果尚未完工，请先创建 Draft pull request。
- Before submitting the pull-request, make sure it has passed your tests, otherwise, please create the Draft pull request first.

- 提交 pull-request 前，请在你的电脑上执行 `npm run format` 对代码进行格式化。
- Please run `npm run format` on your laptop to format the code before submitting the pull-request.

Draft pull request
  - 中文版文档:
    https://docs.github.com/cn/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests

  - Doc in English:
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
-->
