### PR TITLE
Permit adding specific classes to nodes & SVG lines

### DIFF
--- a/src/jsmind.graph.js
+++ b/src/jsmind.graph.js
@@ -59,11 +59,16 @@ class SvgGraph {
         }
         this.lines.length = 0;
     }
-    draw_line(pout, pin, offset, color) {
+    draw_line(pout, pin, offset, color, classList) {
         var line = SvgGraph.c('path');
         line.setAttribute('stroke', color || this.opts.line_color);
         line.setAttribute('stroke-width', this.opts.line_width);
         line.setAttribute('fill', 'transparent');
+        if (classList) {
+            classList.forEach(className => {
+                line.classList.add(className);
+            });
+        }
         this.lines.push(line);
         this.e_svg.appendChild(line);
         this.drawing(

--- a/src/jsmind.view_provider.js
+++ b/src/jsmind.view_provider.js
@@ -505,6 +505,11 @@ export class ViewProvider {
         this._reset_node_custom_style(node._data.view.element, node.data);
     }
     _reset_node_custom_style(node_element, node_data) {
+        if ('classList' in node_data && Array.isArray(node_data['classList'])) {
+            node_data['classList'].forEach((className) => {
+                node_element.classList.add(className);
+            });
+        }
         if ('background-color' in node_data) {
             node_element.style.backgroundColor = node_data['background-color'];
         }

--- a/src/jsmind.view_provider.js
+++ b/src/jsmind.view_provider.js
@@ -505,8 +505,8 @@ export class ViewProvider {
         this._reset_node_custom_style(node._data.view.element, node.data);
     }
     _reset_node_custom_style(node_element, node_data) {
-        if ('classList' in node_data && Array.isArray(node_data['classList'])) {
-            node_data['classList'].forEach((className) => {
+        if (Array.isArray(node_data['nodeClassList'])) {
+            node_data['nodeClassList'].forEach(className => {
                 node_element.classList.add(className);
             });
         }
@@ -591,6 +591,7 @@ export class ViewProvider {
         var pin = null;
         var pout = null;
         var color = null;
+        var classList = null;
         var _offset = this.get_view_offset();
         for (var nodeid in nodes) {
             node = nodes[nodeid];
@@ -603,7 +604,10 @@ export class ViewProvider {
             pin = this.layout.get_node_point_in(node);
             pout = this.layout.get_node_point_out(node.parent);
             color = node.data['leading-line-color'];
-            this.graph.draw_line(pout, pin, _offset, color);
+            classList = Array.isArray(node.data['lineClassList'])
+                ? node.data['lineClassList']
+                : null;
+            this.graph.draw_line(pout, pin, _offset, color, classList);
         }
     }
     // Drag the whole mind map with your mouse, when it's larger that the container


### PR DESCRIPTION
Currently certain aspects of nodes and lines can be modified such as background-color etc. When working with a web publication that supports theming, it is some times not acceptable to directly specify colours in the content of the page. Such aspects must be exclusively managed by CSS.

This change to jsmind adds two node data fields : 

- `nodeClassList`  : an array of strings that will be added to the classList object of the rendered jmnode
- `lineClassList` : SVG only - an array of strings that will be added to the classList object of the rendered SVG path

This allows the content to exclusively  specify intent such as "important". How "important" is relayed to the user is managed exclusively in CSS.

In the following example each branch is assigned a nodeColor class (nodeColor_1, nodeColor_2, etc). The actual colors are managed by CSS theme:  
![image](https://github.com/user-attachments/assets/5a05a4a7-ec58-4b4e-b2e2-dac27e0d3fc1)

In this example a node data looks like : 
```javascript
{
	"id": "gp0mlO8fTKjMkdlhaUwp6c",
	"topic": "Application : Documentaires, Biographies",
	"nodeClassList": ["nodeColor_1"],
	"lineClassList": ["lineColor_1"]
}
```
