### PR TITLE
Debug mousewheel_handle event & programmable mouse zoom key

### DIFF
--- a/src/jsmind.js
+++ b/src/jsmind.js
@@ -125,7 +125,7 @@ export default class jsMind {
         this.view.add_event(this, 'mousedown', this.mousedown_handle);
         this.view.add_event(this, 'click', this.click_handle);
         this.view.add_event(this, 'dblclick', this.dblclick_handle);
-        this.view.add_event(this, 'mousewheel', this.mousewheel_handle, true);
+        this.view.add_event(this, 'wheel', this.mousewheel_handle, true);
     }
     mousedown_handle(e) {
         if (!this.options.default_event_handle['enable_mousedown_handle']) {
@@ -172,7 +172,7 @@ export default class jsMind {
     // Use [Ctrl] + Mousewheel, to zoom in/out.
     mousewheel_handle(e) {
         // Test if mousewheel option is enabled and Ctrl key is pressed.
-        if (!this.options.default_event_handle['enable_mousewheel_handle'] || !e.ctrlKey) {
+        if (!this.options.default_event_handle['enable_mousewheel_handle'] || (this.options.view.zoom.ctrlKey && !e.ctrlKey) || (this.options.view.zoom.shiftKey && !e.shiftKey) || (this.options.view.zoom.altKey && !e.altKey) || (this.options.view.zoom.metaKey && !e.metaKey)) {
             return;
         }
         var evt = e || event;

--- a/src/jsmind.option.js
+++ b/src/jsmind.option.js
@@ -31,6 +31,10 @@ const default_options = {
             min: 0.5,
             max: 2.1,
             step: 0.1,
+            ctrlKey:true,
+            shiftKey:true,
+            altKey:false,
+            metaKey:false,
         },
         custom_node_render: null,
         expander_style: 'char', // [char | number]


### PR DESCRIPTION
By default jsmind zooms on mouse wheel when the CTRL key is pressed, this behaviour can be disabled but cannot be modified.

There is one bug in the current implementation : the use of the non-standard `mousewheel` event rather than the standard `wheel` event. Some browsers such as Firefox do not support `mousewheel`. This pull request corrects this.

The current code enables mouse wheel zooming on ctrlKey exclusively. This is a problem as many browsers use this combo in order to zoom the whole viewport and therefore capture this event without passing it down to the web page.

This proposal does two things:

- It allows one to modify which modifier keys need to be pressed in order to activate mouse wheel zooming
- The default key combination changed to ctrlKey + shiftKey + mousewheel

The zoom view options now allow : 
/
```javascript
let options = {
	view: {
		zoom: {
			min: 0.5,
			max: 2.1,
			step: 0.1,
			ctrlKey:true,
			shiftKey:true,
			altKey:false,
			metaKey:false
		}
	}
}

``` 
