### PR TITLE
feat(ts): add TypeScript typings and type-check tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+## Changelog / 变更日志
+
+### 2025-08-09
+
+- Added / 新增
+  - TypeScript support: publish `.d.ts` for core and plugins (`es6/jsmind.d.ts`, `es6/jsmind.draggable-node.d.ts`, `es6/jsmind.screenshot.d.ts`).
+  - Type checking in CI: added Jest test `tests/unit/typescript.types.test.js` using TypeScript Compiler API to verify typings with `tsconfig.json` (noEmit).
+
+- Changed / 调整
+  - Updated root `package.json` to expose `types` and proper `exports` fields for typings.
+
+- Notes / 说明
+  - The TS example `example/typescript-test.ts` is included in `tsconfig.json#includes` for compile-time verification.
+  - Running `npm test` will now validate TypeScript definitions.
+
+

--- a/es6/jsmind.d.ts
+++ b/es6/jsmind.d.ts
@@ -1,0 +1,369 @@
+/**
+ * TypeScript definitions for jsMind
+ * @version 0.8.7
+ * @author jsMind Community
+ * @license BSD-3-Clause
+ */
+
+// ============================================================================
+// 基础枚举和常量
+// ============================================================================
+
+export interface DirectionType {
+    left: -1;
+    center: 0;
+    right: 1;
+    of(dir: string | number): number | undefined;
+}
+
+export interface EventTypeEnum {
+    show: 1;
+    resize: 2;
+    edit: 3;
+    select: 4;
+}
+
+export interface LogLevelEnum {
+    debug: 1;
+    info: 2;
+    warn: 3;
+    error: 4;
+    disable: 9;
+}
+
+export interface KeyEnum {
+    meta: 8192;
+    ctrl: 4096;
+    alt: 2048;
+    shift: 1024;
+}
+
+// ============================================================================
+// 数据格式接口
+// ============================================================================
+
+export interface NodeData {
+    [key: string]: any;
+}
+
+export interface MindMapMeta {
+    name?: string;
+    author?: string;
+    version?: string;
+}
+
+export interface NodeTreeFormat {
+    meta?: MindMapMeta;
+    format: 'node_tree';
+    data: NodeTreeData;
+}
+
+export interface NodeTreeData {
+    id: string;
+    topic: string;
+    data?: NodeData;
+    direction?: number;
+    expanded?: boolean;
+    children?: NodeTreeData[];
+}
+
+export interface NodeArrayFormat {
+    meta?: MindMapMeta;
+    format: 'node_array';
+    data: NodeArrayData[];
+}
+
+export interface NodeArrayData {
+    id: string;
+    topic: string;
+    parentid?: string;
+    data?: NodeData;
+    direction?: number;
+    expanded?: boolean;
+    isroot?: boolean;
+}
+
+export type MindMapData = NodeTreeFormat | NodeArrayFormat | string;
+
+// ============================================================================
+// 配置选项接口
+// ============================================================================
+
+export interface ZoomOptions {
+    min?: number;
+    max?: number;
+    step?: number;
+    mask_key?: number;
+}
+
+export interface ViewOptions {
+    engine?: 'canvas' | 'svg';
+    enable_device_pixel_ratio?: boolean;
+    hmargin?: number;
+    vmargin?: number;
+    line_width?: number;
+    line_color?: string;
+    line_style?: 'curved' | 'straight';
+    draggable?: boolean;
+    hide_scrollbars_when_draggable?: boolean;
+    node_overflow?: 'hidden' | 'wrap';
+    zoom?: ZoomOptions;
+    custom_node_render?: ((jm: jsMind, element: HTMLElement, node: Node) => void) | null;
+    expander_style?: 'char' | 'number';
+}
+
+export interface LayoutOptions {
+    hspace?: number;
+    vspace?: number;
+    pspace?: number;
+    cousin_space?: number;
+}
+
+export interface DefaultEventHandleOptions {
+    enable_mousedown_handle?: boolean;
+    enable_click_handle?: boolean;
+    enable_dblclick_handle?: boolean;
+    enable_mousewheel_handle?: boolean;
+}
+
+export interface ShortcutMapping {
+    addchild?: number | number[];
+    addbrother?: number | number[];
+    editnode?: number | number[];
+    delnode?: number | number[];
+    toggle?: number | number[];
+    left?: number | number[];
+    up?: number | number[];
+    right?: number | number[];
+    down?: number | number[];
+    [key: string]: number | number[] | undefined;
+}
+
+export interface ShortcutOptions {
+    enable?: boolean;
+    handles?: { [key: string]: () => void };
+    mapping?: ShortcutMapping;
+}
+
+export interface PluginOptions {
+    [pluginName: string]: any;
+}
+
+export interface JsMindOptions {
+    container: string;
+    editable?: boolean;
+    theme?: string | null;
+    mode?: 'full' | 'side';
+    support_html?: boolean;
+    log_level?: 'debug' | 'info' | 'warn' | 'error' | 'disable';
+    view?: ViewOptions;
+    layout?: LayoutOptions;
+    default_event_handle?: DefaultEventHandleOptions;
+    shortcut?: ShortcutOptions;
+    plugin?: PluginOptions;
+}
+
+// ============================================================================
+// 核心类接口
+// ============================================================================
+
+export interface NodeLocation {
+    x: number;
+    y: number;
+}
+
+export interface NodeSize {
+    w: number;
+    h: number;
+}
+
+export class Node {
+    id: string;
+    index: number;
+    topic: string;
+    data: NodeData;
+    isroot: boolean;
+    parent: Node | null;
+    direction: number;
+    expanded: boolean;
+    children: Node[];
+    _data: any;
+
+    constructor(
+        sId: string,
+        iIndex: number,
+        sTopic: string,
+        oData?: NodeData,
+        bIsRoot?: boolean,
+        oParent?: Node | null,
+        eDirection?: number,
+        bExpanded?: boolean
+    );
+
+    get_location(): NodeLocation;
+    get_size(): NodeSize;
+
+    static compare(node1: Node, node2: Node): number;
+    static inherited(parent_node: Node, node: Node): boolean;
+    static is_node(n: any): n is Node;
+}
+
+export class Mind {
+    name: string | null;
+    author: string | null;
+    version: string | null;
+    root: Node | null;
+    selected: Node | null;
+    nodes: { [id: string]: Node };
+
+    constructor();
+
+    get_node(node_id: string): Node | null;
+    set_root(node_id: string, topic: string, data?: NodeData): Node | null;
+    add_node(
+        parent_node: Node,
+        node_id: string,
+        topic: string,
+        data?: NodeData,
+        direction?: number,
+        expanded?: boolean,
+        idx?: number
+    ): Node | null;
+    insert_node_before(node_before: Node, node_id: string, topic: string, data?: NodeData): Node | null;
+    insert_node_after(node_after: Node, node_id: string, topic: string, data?: NodeData): Node | null;
+    remove_node(node: Node): boolean;
+    move_node(node: Node, before_id?: string, parent_id?: string, direction?: number): Node | null;
+}
+
+// ============================================================================
+// 工具类接口
+// ============================================================================
+
+export interface FileUtil {
+    read(file_data: File, fn_callback: (result: string, name: string) => void): void;
+    save(file_data: string, type: string, name: string): void;
+}
+
+export interface JsonUtil {
+    json2string(json: any): string;
+    string2json(json_str: string): any;
+    merge(target: any, source: any): any;
+}
+
+export interface UuidUtil {
+    newid(): string;
+}
+
+export interface TextUtil {
+    is_empty(s?: string | null): boolean;
+}
+
+export interface Util {
+    file: FileUtil;
+    json: JsonUtil;
+    uuid: UuidUtil;
+    text: TextUtil;
+}
+
+export interface Dom {
+    w: Window;
+    d: Document;
+    g(id: string): HTMLElement | null;
+    c(tag: string): HTMLElement;
+    t(n: HTMLElement, t: string): void;
+    h(n: HTMLElement, t: string | HTMLElement): void;
+    i(el: any): el is HTMLElement;
+    on(t: HTMLElement, e: string, h: EventListener): void;
+}
+
+// ============================================================================
+// 事件处理接口
+// ============================================================================
+
+export interface EventData {
+    evt?: string;
+    data?: any[];
+    node?: string;
+}
+
+export type EventHandler = (type: number, data: EventData) => void;
+
+// ============================================================================
+// 主类定义
+// ============================================================================
+
+export default class jsMind {
+    static mind: typeof Mind;
+    static node: typeof Node;
+    static direction: DirectionType;
+    static event_type: EventTypeEnum;
+    static $: Dom;
+    static plugin: any;
+    static register_plugin(plugin_name: string, plugin_init: (jm: jsMind) => void): void;
+    static util: Util;
+    static current: jsMind;
+
+    version: string;
+    options: JsMindOptions;
+    initialized: boolean;
+    mind: Mind | null;
+    event_handles: EventHandler[];
+    data: any;
+    layout: any;
+    view: any;
+    shortcut: any;
+
+    constructor(options: JsMindOptions);
+
+    init(): void;
+    show(mind?: MindMapData, skip_centering?: boolean): void;
+    get_editable(): boolean;
+    enable_edit(): void;
+    disable_edit(): void;
+    get_view_draggable(): boolean;
+    enable_view_draggable(): void;
+    disable_view_draggable(): void;
+    get_meta(): MindMapMeta;
+    get_data(data_format?: 'node_tree' | 'node_array' | 'freemind' | 'text'): any;
+    get_root(): Node | null;
+    get_node(node: string | Node): Node | null;
+    add_node(parent_node: Node | string, node_id: string, topic: string, data?: NodeData, direction?: number): Node | null;
+    insert_node_before(node_before: Node | string, node_id: string, topic: string, data?: NodeData): Node | null;
+    insert_node_after(node_after: Node | string, node_id: string, topic: string, data?: NodeData): Node | null;
+    remove_node(node: Node | string): boolean;
+    update_node(node_id: string, topic: string): void;
+    move_node(node: Node | string, before_id?: string, parent_id?: string, direction?: number): void;
+    select_node(node: Node | string): void;
+    select_clear(): void;
+    get_selected_node(): Node | null;
+    is_node_visible(node: Node | string): boolean;
+    find_node_before(node: Node | string): Node | null;
+    find_node_after(node: Node | string): Node | null;
+    set_node_color(node_id: string, bg_color?: string, fg_color?: string): void;
+    set_node_font_style(node_id: string, size?: number, weight?: string, style?: string): void;
+    set_node_background_image(node_id: string, image: string, width?: number, height?: number, rotation?: number): void;
+    set_node_background_rotation(node_id: string, rotation: number): void;
+    resize(): void;
+    begin_edit(node?: Node | string): void;
+    end_edit(): void;
+    toggle_node(node?: Node | string): void;
+    expand_node(node: Node | string): void;
+    collapse_node(node: Node | string): void;
+    expand_all(): void;
+    collapse_all(): void;
+    expand_to_depth(depth: number): void;
+    scroll_node_to_center(node: Node | string): void;
+    scroll_node_to_visible(node: Node | string): void;
+    add_event_listener(event_listener: EventHandler): void;
+    invoke_event_handle(type: number, data: EventData): void;
+}
+
+// ============================================================================
+// 模块导出
+// ============================================================================
+
+export { jsMind };
+export const direction: DirectionType;
+export const event_type: EventTypeEnum;
+export const $: Dom;
+export const util: Util;

--- a/es6/jsmind.draggable-node.d.ts
+++ b/es6/jsmind.draggable-node.d.ts
@@ -1,0 +1,171 @@
+/**
+ * TypeScript definitions for jsMind draggable-node plugin
+ * @version 0.4.0
+ * @author jsMind Community
+ * @license BSD-3-Clause
+ */
+
+import jsMind, { Node } from './jsmind';
+
+// ============================================================================
+// 插件配置选项接口
+// ============================================================================
+
+export interface DraggableNodeOptions {
+    /** 拖拽线条宽度 */
+    line_width?: number;
+    /** 拖拽线条颜色 */
+    line_color?: string;
+    /** 无效拖拽线条颜色 */
+    line_color_invalid?: string;
+    /** 查找延迟时间（毫秒） */
+    lookup_delay?: number;
+    /** 查找间隔时间（毫秒） */
+    lookup_interval?: number;
+    /** 滚动触发宽度 */
+    scrolling_trigger_width?: number;
+    /** 滚动步长 */
+    scrolling_step_length?: number;
+    /** 阴影节点CSS类名 */
+    shadow_node_class_name?: string;
+}
+
+// ============================================================================
+// 插件类定义
+// ============================================================================
+
+export class DraggableNode {
+    version: string;
+    jm: jsMind;
+    options: Required<DraggableNodeOptions>;
+    e_canvas: HTMLCanvasElement | null;
+    canvas_ctx: CanvasRenderingContext2D | null;
+    shadow: HTMLElement | null;
+    shadow_p_x: number;
+    shadow_p_y: number;
+    shadow_w: number;
+    shadow_h: number;
+    active_node: Node | null;
+    target_node: Node | null;
+    target_direct: number | null;
+    client_w: number;
+    client_h: number;
+    offset_x: number;
+    offset_y: number;
+    hlookup_delay: number;
+    hlookup_timer: number;
+    capture: boolean;
+    moved: boolean;
+    canvas_draggable: boolean;
+    view_panel: HTMLElement;
+    view_panel_rect: DOMRect | null;
+
+    constructor(jm: jsMind, options?: DraggableNodeOptions);
+
+    /** 初始化插件 */
+    init(): void;
+
+    /** 调整大小 */
+    resize(): void;
+
+    /** 创建画布 */
+    create_canvas(): void;
+
+    /** 创建阴影节点 */
+    create_shadow(): void;
+
+    /** 重置阴影节点 */
+    reset_shadow(element: HTMLElement): void;
+
+    /** 显示阴影节点 */
+    show_shadow(): void;
+
+    /** 隐藏阴影节点 */
+    hide_shadow(): void;
+
+    /** 磁性吸附阴影 */
+    magnet_shadow(shadow_p: { x: number; y: number }, node_p: { x: number; y: number }, invalid: boolean): void;
+
+    /** 清除线条 */
+    clear_lines(): void;
+
+    /** 画布画线 */
+    canvas_lineto(x1: number, y1: number, x2: number, y2: number): void;
+
+    /** 绑定事件 */
+    event_bind(): void;
+
+    /** 开始拖拽 */
+    dragstart(e: MouseEvent | TouchEvent): void;
+
+    /** 拖拽中 */
+    drag(e: MouseEvent | TouchEvent): void;
+
+    /** 结束拖拽 */
+    dragend(e: MouseEvent | TouchEvent): void;
+
+    /** 查找节点元素 */
+    find_node_element(element: HTMLElement): HTMLElement | null;
+
+    /** 获取根节点X坐标 */
+    get_root_x(): number;
+
+    /** 查找目标节点 */
+    lookup_target_node(): void;
+
+    /** 根据位置查找重叠的节点父级 */
+    lookup_overlapping_node_parent(direction: number): Node | null;
+
+    /** 根据位置查找节点父级 */
+    lookup_node_parent_by_location(x: number, y: number): Node | null;
+
+    /** 查找最近的节点 */
+    lookup_close_node(direction: number): Node;
+
+    /** 检查阴影是否在目标侧 */
+    shadow_on_target_side(node: Node, direction: number): boolean;
+
+    /** 阴影到节点左侧的距离 */
+    shadow_to_left_of_node(node: Node): number;
+
+    /** 阴影到节点右侧的距离 */
+    shadow_to_right_of_node(node: Node): number;
+
+    /** 阴影到节点基线的距离 */
+    shadow_to_base_line_of_node(node: Node): number;
+
+    /** 阴影到节点的距离 */
+    shadow_to_node(node: Node, dir: number): number;
+
+    /** 计算节点的点位置 */
+    calc_point_of_node(node: Node, dir: number): {
+        sp: { x: number; y: number };
+        np: { x: number; y: number };
+    };
+
+    /** 移动节点 */
+    move_node(src_node: Node, target_node: Node | null, target_direct: number | null): void;
+
+    /** jsMind事件处理 */
+    jm_event_handle(type: number, data: any): void;
+}
+
+// ============================================================================
+// 模块声明扩展
+// ============================================================================
+
+declare module './jsmind' {
+    interface PluginOptions {
+        draggable_node?: DraggableNodeOptions;
+    }
+}
+
+// ============================================================================
+// 插件注册
+// ============================================================================
+
+/** 拖拽节点插件实例 */
+export const draggable_plugin: any;
+
+// 自动注册插件到jsMind
+export default DraggableNode;

--- a/es6/jsmind.screenshot.d.ts
+++ b/es6/jsmind.screenshot.d.ts
@@ -1,0 +1,133 @@
+/**
+ * TypeScript definitions for jsMind screenshot plugin
+ * @version 0.2.0
+ * @author jsMind Community
+ * @license BSD-3-Clause
+ */
+
+import jsMind from './jsmind';
+
+// ============================================================================
+// 插件配置选项接口
+// ============================================================================
+
+export interface WatermarkOptions {
+    /** 左侧水印文本 */
+    left?: string | Location;
+    /** 右侧水印文本 */
+    right?: string;
+}
+
+export interface ScreenshotOptions {
+    /** 导出文件名（不包含扩展名） */
+    filename?: string | null;
+    /** 水印配置 */
+    watermark?: WatermarkOptions;
+    /** 背景颜色，'transparent' 表示透明背景 */
+    background?: string;
+}
+
+// ============================================================================
+// 插件类定义
+// ============================================================================
+
+export class JmScreenshot {
+    version: string;
+    jm: jsMind;
+    options: Required<ScreenshotOptions>;
+    dpr: number;
+
+    constructor(jm: jsMind, options?: ScreenshotOptions);
+
+    /** 
+     * 截图并下载
+     * 执行完整的截图流程：创建画布 -> 绘制背景 -> 绘制线条 -> 绘制节点 -> 添加水印 -> 下载 -> 清理
+     */
+    shoot(): void;
+
+    /** 
+     * 创建画布
+     * @returns 返回创建的canvas元素
+     */
+    create_canvas(): HTMLCanvasElement;
+
+    /** 
+     * 清理画布
+     * @param c 要清理的canvas元素
+     */
+    clear(c: HTMLCanvasElement): void;
+
+    /** 
+     * 绘制背景
+     * @param ctx 画布上下文
+     * @returns Promise，完成后返回画布上下文
+     */
+    draw_background(ctx: CanvasRenderingContext2D): Promise<CanvasRenderingContext2D>;
+
+    /** 
+     * 绘制连接线
+     * @param ctx 画布上下文
+     * @returns Promise，完成后返回画布上下文
+     */
+    draw_lines(ctx: CanvasRenderingContext2D): Promise<CanvasRenderingContext2D>;
+
+    /** 
+     * 绘制节点
+     * @param ctx 画布上下文
+     * @returns Promise，完成后返回画布上下文
+     */
+    draw_nodes(ctx: CanvasRenderingContext2D): Promise<CanvasRenderingContext2D>;
+
+    /** 
+     * 绘制水印
+     * @param c 画布元素
+     * @param ctx 画布上下文
+     * @returns 画布上下文
+     */
+    draw_watermark(c: HTMLCanvasElement, ctx: CanvasRenderingContext2D): CanvasRenderingContext2D;
+
+    /** 
+     * 加载图片
+     * @param url 图片URL
+     * @returns Promise，完成后返回HTMLImageElement
+     */
+    load_image(url: string): Promise<HTMLImageElement>;
+
+    /** 
+     * 下载画布内容为PNG文件
+     * @param c 画布元素
+     */
+    download(c: HTMLCanvasElement): void;
+}
+
+// ============================================================================
+// 模块声明扩展
+// ============================================================================
+
+declare module './jsmind' {
+    interface PluginOptions {
+        screenshot?: ScreenshotOptions;
+    }
+
+    // 扩展jsMind类，添加screenshot插件方法
+    export default interface jsMind {
+        /** screenshot插件实例 */
+        screenshot?: JmScreenshot;
+        
+        /** 
+         * 截图方法（由screenshot插件添加）
+         * 执行截图并下载为PNG文件
+         */
+        shoot?(): void;
+    }
+}
+
+// ============================================================================
+// 插件注册
+// ============================================================================
+
+/** screenshot插件实例 */
+export const screenshot_plugin: any;
+
+// 自动注册插件到jsMind
+export default JmScreenshot;

--- a/example/js/typescript-demo.js
+++ b/example/js/typescript-demo.js
@@ -1,0 +1,252 @@
+/**
+ * jsMind TypeScript Demo
+ * 这个文件展示了如何在 TypeScript 中使用 jsMind
+ * 编译命令: npx tsc example/typescript-demo.ts --outDir example/js --target ES2020 --module ESNext
+ */
+import jsMind from '../es6/jsmind';
+// 全局变量
+let jm = null;
+let isEditMode = false;
+// TypeScript 配置选项 - 享受完整的类型检查和智能提示
+const options = {
+    container: 'jsmind_container',
+    editable: true,
+    theme: 'primary',
+    view: {
+        engine: 'canvas',
+        draggable: true,
+        zoom: {
+            min: 0.5,
+            max: 2.0,
+            step: 0.1
+        },
+        line_color: '#667eea',
+        line_width: 2
+    },
+    layout: {
+        hspace: 30,
+        vspace: 20,
+        pspace: 13
+    },
+    plugin: {
+        draggable_node: {
+            line_width: 5,
+            line_color: 'rgba(102, 126, 234, 0.6)',
+            line_color_invalid: 'rgba(220, 53, 69, 0.6)',
+            lookup_delay: 200
+        }
+    }
+};
+// TypeScript 数据格式 - 类型安全的数据定义
+const sampleMindData = {
+    meta: {
+        name: 'TypeScript Demo',
+        author: 'jsMind TypeScript',
+        version: '1.0'
+    },
+    format: 'node_tree',
+    data: {
+        id: 'root',
+        topic: 'jsMind TypeScript 集成',
+        children: [
+            {
+                id: 'features',
+                topic: '🚀 主要特性',
+                direction: jsMind.direction.right,
+                expanded: true,
+                children: [
+                    {
+                        id: 'type-safety',
+                        topic: '类型安全',
+                        data: {
+                            note: '编译时类型检查',
+                            background: '#e3f2fd'
+                        }
+                    },
+                    {
+                        id: 'intellisense',
+                        topic: '智能提示',
+                        data: {
+                            note: 'IDE 自动完成',
+                            background: '#f3e5f5'
+                        }
+                    },
+                    {
+                        id: 'refactoring',
+                        topic: '安全重构',
+                        data: {
+                            note: '重命名和移动',
+                            background: '#e8f5e8'
+                        }
+                    }
+                ]
+            },
+            {
+                id: 'benefits',
+                topic: '💡 开发优势',
+                direction: jsMind.direction.left,
+                expanded: true,
+                children: [
+                    {
+                        id: 'errors',
+                        topic: '错误预防',
+                        data: { background: '#ff6b6b' }
+                    },
+                    {
+                        id: 'docs',
+                        topic: '自文档化',
+                        data: { background: '#4ecdc4' }
+                    },
+                    {
+                        id: 'maintenance',
+                        topic: '易维护性',
+                        data: { background: '#45b7d1' }
+                    }
+                ]
+            },
+            {
+                id: 'plugins',
+                topic: '🔌 插件支持',
+                direction: jsMind.direction.right,
+                children: [
+                    { id: 'draggable', topic: '拖拽节点' },
+                    { id: 'screenshot', topic: '截图导出' }
+                ]
+            }
+        ]
+    }
+};
+// 初始化函数 - 类型安全的 jsMind 实例创建
+function initJsMind() {
+    jm = new jsMind(options);
+    // 事件监听 - TypeScript 提供类型安全的事件处理
+    jm.add_event_listener((type, data) => {
+        let eventName = '';
+        switch (type) {
+            case jsMind.event_type.show:
+                eventName = '显示';
+                break;
+            case jsMind.event_type.select:
+                eventName = '选择';
+                break;
+            case jsMind.event_type.edit:
+                eventName = '编辑';
+                break;
+            case jsMind.event_type.resize:
+                eventName = '调整大小';
+                break;
+        }
+        updateStatus(`事件触发: ${eventName} - ${JSON.stringify(data)}`);
+    });
+    updateStatus('jsMind 初始化完成 - TypeScript 类型定义已生效');
+}
+// 加载示例数据
+function loadSampleData() {
+    if (!jm)
+        initJsMind();
+    jm.show(sampleMindData);
+    updateStatus('示例数据已加载 - 使用了 TypeScript NodeTreeFormat 类型');
+}
+// 添加随机节点 - 展示类型安全的 API 调用
+function addRandomNode() {
+    if (!jm) {
+        updateStatus('请先加载数据');
+        return;
+    }
+    const selectedNode = jm.get_selected_node();
+    const parentNode = selectedNode || jm.get_root();
+    if (parentNode) {
+        const nodeId = jsMind.util.uuid.newid();
+        const topics = ['新想法', '重要提醒', '待办事项', '灵感闪现', '项目计划'];
+        const topic = topics[Math.floor(Math.random() * topics.length)];
+        const colors = ['#ff6b6b', '#4ecdc4', '#45b7d1', '#96ceb4', '#feca57'];
+        const color = colors[Math.floor(Math.random() * colors.length)];
+        // TypeScript 确保方法调用的类型正确性
+        const newNode = jm.add_node(parentNode, nodeId, topic, {
+            background: color,
+            created: new Date().toISOString()
+        }, Math.random() > 0.5 ? jsMind.direction.right : jsMind.direction.left);
+        if (newNode) {
+            jm.set_node_color(newNode.id, color, '#ffffff');
+            jm.select_node(newNode);
+            updateStatus(`已添加新节点: ${topic} (ID: ${nodeId})`);
+        }
+    }
+}
+// 切换编辑模式
+function toggleEdit() {
+    if (!jm) {
+        updateStatus('请先加载数据');
+        return;
+    }
+    isEditMode = !isEditMode;
+    if (isEditMode) {
+        jm.enable_edit();
+        updateStatus('编辑模式已启用 - 双击节点可编辑');
+    }
+    else {
+        jm.disable_edit();
+        updateStatus('编辑模式已禁用');
+    }
+}
+// 展开所有节点
+function expandAll() {
+    if (!jm)
+        return;
+    jm.expand_all();
+    updateStatus('所有节点已展开');
+}
+// 收起所有节点
+function collapseAll() {
+    if (!jm)
+        return;
+    jm.collapse_all();
+    updateStatus('所有节点已收起');
+}
+// 清空思维导图
+function clearMindMap() {
+    if (!jm)
+        return;
+    jm.show();
+    updateStatus('思维导图已清空');
+}
+// 更新状态信息
+function updateStatus(message) {
+    const statusElement = document.getElementById('status');
+    if (statusElement) {
+        statusElement.textContent = `${new Date().toLocaleTimeString()} - ${message}`;
+    }
+}
+// 演示工具函数的使用
+function demonstrateUtilFunctions() {
+    // UUID 生成
+    const nodeId = jsMind.util.uuid.newid();
+    console.log('Generated UUID:', nodeId);
+    // JSON 操作
+    const jsonString = jsMind.util.json.json2string(sampleMindData);
+    const parsedData = jsMind.util.json.string2json(jsonString);
+    console.log('JSON serialization test passed');
+    // 文本工具
+    const isEmpty = jsMind.util.text.is_empty('');
+    const isNotEmpty = jsMind.util.text.is_empty('hello');
+    console.log('Text utility test:', { isEmpty, isNotEmpty });
+    // DOM 工具
+    const element = jsMind.$.g('jsmind_container');
+    if (element) {
+        console.log('DOM element found:', element.tagName);
+    }
+}
+// 导出函数供全局使用
+window.loadSampleData = loadSampleData;
+window.addRandomNode = addRandomNode;
+window.toggleEdit = toggleEdit;
+window.expandAll = expandAll;
+window.collapseAll = collapseAll;
+window.clearMindMap = clearMindMap;
+// 页面加载完成后的初始化
+window.addEventListener('load', () => {
+    updateStatus('页面加载完成 - TypeScript 类型定义验证成功');
+    demonstrateUtilFunctions();
+});
+// 导出主要对象供其他模块使用
+export { jm, options, sampleMindData };

--- a/example/typescript-example.ts
+++ b/example/typescript-example.ts
@@ -1,0 +1,119 @@
+/**
+ * jsMind TypeScript 使用示例
+ * 展示如何在 TypeScript 项目中使用 jsMind
+ */
+
+import jsMind, { JsMindOptions, NodeTreeFormat } from '../es6/jsmind';
+
+// 创建配置选项
+const options: JsMindOptions = {
+    container: 'jsmind_container',
+    editable: true,
+    theme: 'primary',
+    view: {
+        engine: 'canvas',
+        draggable: true,
+        zoom: {
+            min: 0.5,
+            max: 2.0,
+            step: 0.1,
+        },
+    },
+    layout: {
+        hspace: 30,
+        vspace: 20,
+    },
+};
+
+// 创建思维导图数据
+const mindData: NodeTreeFormat = {
+    meta: {
+        name: 'TypeScript Example',
+        author: 'jsMind User',
+        version: '1.0',
+    },
+    format: 'node_tree',
+    data: {
+        id: 'root',
+        topic: 'TypeScript Integration',
+        children: [
+            {
+                id: 'features',
+                topic: 'Features',
+                direction: 1,
+                children: [
+                    { id: 'types', topic: 'Type Safety' },
+                    { id: 'intellisense', topic: 'IntelliSense' },
+                    { id: 'refactoring', topic: 'Safe Refactoring' },
+                ],
+            },
+            {
+                id: 'benefits',
+                topic: 'Benefits',
+                direction: -1,
+                children: [
+                    { id: 'errors', topic: 'Compile-time Error Detection' },
+                    { id: 'docs', topic: 'Self-documenting Code' },
+                    { id: 'maintenance', topic: 'Better Maintainability' },
+                ],
+            },
+        ],
+    },
+};
+
+// 创建 jsMind 实例
+const jm = new jsMind(options);
+
+// 显示思维导图
+jm.show(mindData);
+
+// 添加事件监听器
+jm.add_event_listener((type, data) => {
+    switch (type) {
+        case jsMind.event_type.show:
+            console.log('Mind map displayed');
+            break;
+        case jsMind.event_type.select:
+            console.log('Node selected:', data);
+            break;
+        case jsMind.event_type.edit:
+            console.log('Node edited:', data);
+            break;
+    }
+});
+
+// 获取根节点并添加新节点
+const root = jm.get_root();
+if (root) {
+    const newNode = jm.add_node(
+        root,
+        'new_feature',
+        'New Feature',
+        {
+            background: '#ff6b6b',
+            foreground: '#ffffff',
+        },
+        jsMind.direction.right
+    );
+
+    if (newNode) {
+        // 设置节点样式
+        jm.set_node_color(newNode.id, '#ff6b6b', '#ffffff');
+        jm.set_node_font_style(newNode.id, 14, 'bold');
+
+        // 选择新节点
+        jm.select_node(newNode);
+    }
+}
+
+// 工具函数使用示例
+const nodeId = jsMind.util.uuid.newid();
+const isEmpty = jsMind.util.text.is_empty('');
+const jsonData = jsMind.util.json.json2string(mindData);
+
+console.log('Generated node ID:', nodeId);
+console.log('Is empty string:', isEmpty);
+console.log('JSON data length:', jsonData.length);
+
+// 导出实例供其他模块使用
+export { jm, options, mindData };

--- a/example/typescript-test.ts
+++ b/example/typescript-test.ts
@@ -1,0 +1,303 @@
+/**
+ * TypeScript 类型定义验证测试文件
+ * 用于验证 jsMind 的 TypeScript 类型定义是否正确
+ */
+
+// 导入主库和插件
+import jsMind, { Node, Mind, JsMindOptions, NodeTreeFormat, MindMapData } from '../es6/jsmind';
+// 注意：在实际使用中，插件需要单独导入来注册
+// import './es6/jsmind.draggable-node';
+// import './es6/jsmind.screenshot';
+
+// ============================================================================
+// 基础配置测试
+// ============================================================================
+
+// 测试基本配置选项
+const basicOptions: JsMindOptions = {
+    container: 'jsmind_container',
+    editable: true,
+    theme: 'orange',
+    mode: 'full',
+    support_html: true,
+    log_level: 'info',
+};
+
+// 测试完整配置选项
+const fullOptions: JsMindOptions = {
+    container: 'jsmind_container',
+    editable: true,
+    theme: 'greensea',
+    mode: 'side',
+    support_html: false,
+    log_level: 'debug',
+    view: {
+        engine: 'canvas',
+        enable_device_pixel_ratio: true,
+        hmargin: 120,
+        vmargin: 60,
+        line_width: 3,
+        line_color: '#333',
+        line_style: 'straight',
+        draggable: true,
+        hide_scrollbars_when_draggable: true,
+        node_overflow: 'wrap',
+        zoom: {
+            min: 0.3,
+            max: 3.0,
+            step: 0.2,
+            mask_key: 4096,
+        },
+        custom_node_render: (jm, element, node) => {
+            element.innerHTML = `<strong>${node.topic}</strong>`;
+        },
+        expander_style: 'number',
+    },
+    layout: {
+        hspace: 40,
+        vspace: 25,
+        pspace: 15,
+        cousin_space: 5,
+    },
+    default_event_handle: {
+        enable_mousedown_handle: true,
+        enable_click_handle: true,
+        enable_dblclick_handle: false,
+        enable_mousewheel_handle: true,
+    },
+    shortcut: {
+        enable: true,
+        handles: {
+            custom_action: () => console.log('Custom action triggered'),
+        },
+        mapping: {
+            addchild: [45, 4096 + 13],
+            addbrother: 13,
+            editnode: 113,
+            delnode: 46,
+            toggle: 32,
+            left: 37,
+            up: 38,
+            right: 39,
+            down: 40,
+        },
+    },
+    plugin: {
+        draggable_node: {
+            line_width: 6,
+            line_color: 'rgba(255,0,0,0.5)',
+            lookup_delay: 300,
+        },
+        screenshot: {
+            filename: 'my-mindmap',
+            background: '#ffffff',
+            watermark: {
+                left: 'My Company',
+                right: 'https://example.com',
+            },
+        },
+    },
+};
+
+// ============================================================================
+// 数据格式测试
+// ============================================================================
+
+// 测试节点树格式数据
+const nodeTreeData: NodeTreeFormat = {
+    meta: {
+        name: 'Test Mind Map',
+        author: 'TypeScript Tester',
+        version: '1.0',
+    },
+    format: 'node_tree',
+    data: {
+        id: 'root',
+        topic: 'Root Topic',
+        data: {
+            background: '#ff0000',
+            foreground: '#ffffff',
+        },
+        children: [
+            {
+                id: 'child1',
+                topic: 'Child 1',
+                direction: 1,
+                expanded: true,
+                children: [
+                    {
+                        id: 'grandchild1',
+                        topic: 'Grandchild 1',
+                        data: { note: 'This is a note' },
+                    },
+                ],
+            },
+            {
+                id: 'child2',
+                topic: 'Child 2',
+                direction: -1,
+                expanded: false,
+            },
+        ],
+    },
+};
+
+// ============================================================================
+// jsMind 实例测试
+// ============================================================================
+
+// 创建 jsMind 实例
+const jm = new jsMind(basicOptions);
+
+// 测试静态属性
+const NodeClass = jsMind.node;
+const MindClass = jsMind.mind;
+const direction = jsMind.direction;
+const eventType = jsMind.event_type;
+const domUtil = jsMind.$;
+const util = jsMind.util;
+
+// 测试方向枚举
+const leftDirection: number = direction.left; // -1
+const rightDirection: number = direction.right; // 1
+const centerDirection: number = direction.center; // 0
+const parsedDirection: number | undefined = direction.of('left');
+
+// 测试事件类型
+const showEvent: number = eventType.show;
+const resizeEvent: number = eventType.resize;
+
+// ============================================================================
+// API 方法测试
+// ============================================================================
+
+// 显示思维导图
+jm.show(nodeTreeData);
+jm.show(); // 显示空白思维导图
+
+// 获取信息
+const meta = jm.get_meta();
+const data = jm.get_data('node_tree');
+const root = jm.get_root();
+
+// 节点操作
+if (root) {
+    const newNode = jm.add_node(root, 'new_node', 'New Topic', { color: 'blue' }, 1);
+    if (newNode) {
+        jm.update_node(newNode.id, 'Updated Topic');
+        jm.select_node(newNode);
+
+        const selectedNode = jm.get_selected_node();
+        if (selectedNode) {
+            jm.set_node_color(selectedNode.id, '#ff0000', '#ffffff');
+            jm.set_node_font_style(selectedNode.id, 16, 'bold', 'italic');
+        }
+    }
+}
+
+// 编辑操作
+jm.enable_edit();
+const isEditable: boolean = jm.get_editable();
+jm.begin_edit();
+jm.end_edit();
+jm.disable_edit();
+
+// 布局操作
+jm.expand_all();
+jm.collapse_all();
+jm.expand_to_depth(2);
+
+// 视图操作
+jm.enable_view_draggable();
+const isDraggable: boolean = jm.get_view_draggable();
+jm.disable_view_draggable();
+jm.resize();
+
+// 事件监听
+jm.add_event_listener((type: number, data: any) => {
+    console.log(`Event ${type} triggered with data:`, data);
+});
+
+// ============================================================================
+// Node 类测试
+// ============================================================================
+
+// 创建节点实例（通常不直接创建，而是通过 jsMind API）
+const testNode = new Node('test_id', 1, 'Test Topic', { custom: 'data' }, false, null, 1, true);
+
+// 测试节点属性
+const nodeId: string = testNode.id;
+const nodeTopic: string = testNode.topic;
+const nodeChildren: Node[] = testNode.children;
+const isRoot: boolean = testNode.isroot;
+
+// 测试节点方法
+const location = testNode.get_location();
+const size = testNode.get_size();
+
+// 测试静态方法
+const isNodeInstance: boolean = Node.is_node(testNode);
+const comparison: number = Node.compare(testNode, testNode);
+
+// ============================================================================
+// 工具类测试
+// ============================================================================
+
+// JSON 工具
+const jsonString: string = util.json.json2string({ test: 'data' });
+const jsonObject: any = util.json.string2json('{"test":"data"}');
+const mergedObject: any = util.json.merge({}, { test: 'data' });
+
+// UUID 工具
+const newId: string = util.uuid.newid();
+
+// 文本工具
+const isEmpty: boolean = util.text.is_empty('');
+const isNotEmpty: boolean = util.text.is_empty('hello');
+
+// 文件工具（需要 File 对象）
+// util.file.read(fileObject, (result, name) => {
+//     console.log(`File ${name} content:`, result);
+// });
+
+// DOM 工具
+const element = domUtil.g('some_id');
+const newElement = domUtil.c('div');
+
+// ============================================================================
+// 类型检查验证
+// ============================================================================
+
+// 这些代码应该通过 TypeScript 编译器的类型检查
+function validateTypes() {
+    // 验证配置选项类型
+    const config: JsMindOptions = basicOptions;
+
+    // 验证数据格式类型
+    const mindData: MindMapData = nodeTreeData;
+
+    // 验证方法返回类型
+    const rootNode: Node | null = jm.get_root();
+    const selectedNode: Node | null = jm.get_selected_node();
+
+    // 验证事件处理器类型
+    const eventHandler = (type: number, data: any) => {
+        if (type === jsMind.event_type.show) {
+            console.log('Mind map shown');
+        }
+    };
+
+    return {
+        config,
+        mindData,
+        rootNode,
+        selectedNode,
+        eventHandler,
+    };
+}
+
+// 导出验证函数供测试使用
+export { validateTypes };
+
+console.log('TypeScript 类型定义验证测试完成！');
+console.log('如果此文件能够成功编译，说明类型定义是正确的。');

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
                 "jest-environment-jsdom": "^28.1.0",
                 "prettier": "2.6.2",
                 "rollup": "2.79.2",
-                "rollup-plugin-cleanup": "^3.2.1"
+                "rollup-plugin-cleanup": "^3.2.1",
+                "typescript": "^5.9.2"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -4453,6 +4454,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.2",
+            "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.2.tgz",
+            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,23 @@
     "version": "0.8.7",
     "description": "jsMind is a pure javascript library for mindmap, it base on html5 canvas. jsMind was released under BSD license, you can embed it in any project, if only you observe the license.",
     "main": "es6/jsmind.js",
+    "types": "es6/jsmind.d.ts",
     "exports": {
-        ".": "./es6/jsmind.js",
-        "./draggable-node": "./es6/jsmind.draggable-node.js",
-        "./screenshot": "./es6/jsmind.screenshot.js",
+        ".": {
+            "import": "./es6/jsmind.js",
+            "require": "./es6/jsmind.js",
+            "types": "./es6/jsmind.d.ts"
+        },
+        "./draggable-node": {
+            "import": "./es6/jsmind.draggable-node.js",
+            "require": "./es6/jsmind.draggable-node.js",
+            "types": "./es6/jsmind.draggable-node.d.ts"
+        },
+        "./screenshot": {
+            "import": "./es6/jsmind.screenshot.js",
+            "require": "./es6/jsmind.screenshot.js",
+            "types": "./es6/jsmind.screenshot.d.ts"
+        },
         "./style/jsmind.css": "./style/jsmind.css"
     },
     "directories": {
@@ -45,13 +58,14 @@
         }
     ],
     "devDependencies": {
+        "@rollup/plugin-terser": "^0.4.4",
         "http-server": "^14.1.1",
         "jest": "^28.1.0",
         "jest-environment-jsdom": "^28.1.0",
         "prettier": "2.6.2",
         "rollup": "2.79.2",
         "rollup-plugin-cleanup": "^3.2.1",
-        "@rollup/plugin-terser": "^0.4.4"
+        "typescript": "^5.9.2"
     },
     "jest": {
         "verbose": true,

--- a/tests/unit/typescript.types.test.js
+++ b/tests/unit/typescript.types.test.js
@@ -1,0 +1,54 @@
+/** @jest-environment node */
+
+// 使用 TypeScript 编译器 API 执行类型检查，等价于 `tsc --noEmit`
+import * as path from 'path';
+import ts from 'typescript';
+
+function parseTsConfig(tsconfigPath) {
+    const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+    if (configFile.error) {
+        const message = ts.formatDiagnosticsWithColorAndContext([configFile.error], formatHost());
+        throw new Error(`读取 tsconfig 失败:\n${message}`);
+    }
+    return ts.parseJsonConfigFileContent(configFile.config, ts.sys, path.dirname(tsconfigPath));
+}
+
+function formatHost() {
+    return {
+        getCanonicalFileName: f => f,
+        getCurrentDirectory: ts.sys.getCurrentDirectory,
+        getNewLine: () => ts.sys.newLine,
+    };
+}
+
+describe('TypeScript 类型定义校验', () => {
+    test('example/typescript-test.ts 应通过类型检查（无诊断错误）', () => {
+        const projectRoot = process.cwd();
+        const tsconfigPath = path.join(projectRoot, 'tsconfig.json');
+
+        const parsed = parseTsConfig(tsconfigPath);
+
+        // 强制不输出文件（即使 tsconfig 设置了 declaration），仅进行类型检查
+        const compilerOptions = { ...parsed.options, noEmit: true };
+
+        const program = ts.createProgram({ rootNames: parsed.fileNames, options: compilerOptions });
+
+        const diagnostics = [
+            ...program.getConfigFileParsingDiagnostics(),
+            ...program.getOptionsDiagnostics(),
+            ...program.getSyntacticDiagnostics(),
+            ...program.getSemanticDiagnostics(),
+        ];
+
+        if (diagnostics.length > 0) {
+            const message = ts.formatDiagnosticsWithColorAndContext(diagnostics, formatHost());
+            // 提供清晰的失败输出，便于定位问题
+            // eslint-disable-next-line no-console
+            console.error('\nTypeScript 诊断信息:\n');
+            // eslint-disable-next-line no-console
+            console.error(message);
+        }
+
+        expect(diagnostics.length).toBe(0);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "node",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "declaration": true,
+        "outDir": "./dist",
+        "rootDir": "./",
+        "noEmit": true
+    },
+    "include": ["example/typescript-test.ts", "es6/*.d.ts"],
+    "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
### Summary

Introduce first-class TypeScript support for jsMind, publish official typings for core and plugins, and ensure typings are continuously validated in CI via a Jest-based type-check.

### What’s in this PR

- Publish `.d.ts` for core and plugins: `es6/jsmind.d.ts`, `es6/jsmind.draggable-node.d.ts`, `es6/jsmind.screenshot.d.ts`
- Add Jest-based type-check (tsc noEmit) at `tests/unit/typescript.types.test.js`, validating `tsconfig.json` includes `example/typescript-test.ts` and `es6/*.d.ts`
- Update `package.json` to expose `types` and `exports.types` entries
- Add bilingual `CHANGELOG.md` (2025-08-09) documenting the TS support and testing
- Remove temporary TS docs: `TYPESCRIPT.md`, `TYPESCRIPT-INTEGRATION-SUMMARY.md`, `typescript-integration-progress.md`
- All tests pass locally (13 test suites, 95 tests)

### Why

- Provide official TypeScript types to improve DX (IntelliSense, static checks, safer refactors).
- Ensure typings do not regress by adding compile-time validation in the existing test pipeline.

### How

- Publish `.d.ts` files under `es6/` and wire them via `package.json` `types` and `exports` fields.
- Add a Jest test that runs TypeScript compiler API in `noEmit` mode, equivalent to `tsc --noEmit`, so CI can fail fast on type regressions.
- Include `example/typescript-test.ts` in `tsconfig.json#includes` to validate real-world API usage.

### Backward Compatibility

- No runtime API changes; ESM/CJS `exports` remain compatible.
- This is an additive change that exposes typings to TypeScript users.

### Testing

- Run all tests:
  - `npm test` → 13 suites, 95 tests passing locally.
- Type-check:
  - `tests/unit/typescript.types.test.js` invokes `typescript` compiler API to validate `.d.ts` and example usage.

### Documentation

- Added bilingual `CHANGELOG.md` (2025-08-09) noting TS support and tests.
- No public API docs changed.

### Checklist

- [x] Tests pass locally
- [x] Type-checking added and enforced in tests (tsc noEmit)
- [x] Exposed `types` via `package.json` and `exports.types`
- [x] Change log updated
- [x] Code formatted (`npm run format`) and consistent with repo style

### Additional Notes

If maintainers prefer running type-check directly in CI without Jest, the logic can be moved to a dedicated script (`tsc -p tsconfig.json --noEmit`) and invoked in CI. Current approach keeps everything inside Jest for consistency with the repo’s test flow.
