### PR TITLE
feat(plugin): multiline text editing plugin with dynamic sizing

### DIFF
--- a/.config/rollup.config.js
+++ b/.config/rollup.config.js
@@ -73,4 +73,29 @@ export default [
             }),
         ],
     },
+    {
+        input: 'src/plugins/jsmind.multiline-text.js',
+        output: {
+            name: 'jsMindMultilineText',
+            file: 'es6/jsmind.multiline-text.js',
+            format: 'umd',
+            banner: '/**\n* @license BSD-3-Clause\n* @copyright 2014-2025 hizzgdev@163.com\n*\n* Project Home:\n*   https://github.com/hizzgdev/jsmind/\n*/',
+            sourcemap: true,
+            globals: {
+                jsmind: 'jsMind',
+            },
+            exports: 'named',
+        },
+        external: ['jsmind'],
+        plugins: [
+            cleanup({
+                comments: 'none',
+            }),
+            terser({
+                output: {
+                    comments: 'all',
+                },
+            }),
+        ],
+    },
 ];

--- a/docs/en/plugin-multiline-text.md
+++ b/docs/en/plugin-multiline-text.md
@@ -1,0 +1,315 @@
+# Multiline Text Plugin
+
+The Multiline Text Plugin provides complete multiline text support for jsMind, including display and editing capabilities.
+
+## Features
+
+- ✅ **Multiline Text Display**: Display multiline text in nodes
+- ✅ **Multiline Text Editing**: Rich text editor using `contentEditable`
+- ✅ **Auto Word Wrap**: Automatic line wrapping when text exceeds maximum width
+- ✅ **Auto Height Expansion**: Editor height automatically adjusts to content
+- ✅ **Keyboard Shortcuts**:
+  - `Shift + Enter`: Insert line break
+  - `Enter`: Save changes
+  - `Esc`: Cancel editing
+  - `Tab`: Save changes
+- ✅ **Text Normalization**: Automatically trim whitespace, normalize line endings, limit consecutive blank lines
+
+## Installation
+
+### Method 1: UMD (Browser)
+
+```html
+<script src="es6/jsmind.js"></script>
+<script src="es6/jsmind.multiline-text.js"></script>
+```
+
+### Method 2: ES6 Module
+
+```javascript
+import jsMind from './es6/jsmind.js';
+import { createMultilineRender } from './es6/jsmind.multiline-text.js';
+```
+
+## Usage
+
+### Basic Usage
+
+```javascript
+// UMD (Browser)
+const options = {
+    container: 'jsmind_container',
+    editable: true,
+    view: {
+        // Use the custom render function provided by the plugin
+        custom_node_render: jsMindMultilineText.createMultilineRender({
+            text_width: 200,
+            line_height: '1.5',
+        })
+    },
+    plugin: {
+        multiline_text: {
+            text_width: 200,
+            line_height: '1.5',
+        }
+    }
+};
+
+const jm = new jsMind(options);
+jm.show(mind_data);
+```
+
+### ES6 Module Usage
+
+```javascript
+import jsMind from './es6/jsmind.js';
+import { createMultilineRender } from './es6/jsmind.multiline-text.js';
+
+const options = {
+    container: 'jsmind_container',
+    editable: true,
+    view: {
+        custom_node_render: createMultilineRender({
+            text_width: 200,
+            line_height: '1.5',
+        })
+    },
+    plugin: {
+        multiline_text: {
+            text_width: 200,
+            line_height: '1.5',
+        }
+    }
+};
+
+const jm = new jsMind(options);
+jm.show(mind_data);
+```
+
+## Configuration Options
+
+### `createMultilineRender(options)`
+
+Create a custom node render function for multiline text.
+
+**Parameters:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `text_width` | `number` | `200` | Maximum width for multiline text nodes (px) |
+| `line_height` | `string` | `'1.5'` | Line height for text |
+
+**Returns:** `function(jsMind, HTMLElement, Node): boolean`
+
+**Example:**
+
+```javascript
+const customRender = createMultilineRender({
+    text_width: 250,
+    line_height: '1.6',
+});
+```
+
+### Plugin Options
+
+Configure the plugin behavior in `options.plugin.multiline_text`:
+
+```javascript
+{
+    plugin: {
+        multiline_text: {
+            text_width: 200,      // Maximum width for multiline text
+            line_height: '1.5',   // Line height
+        }
+    }
+}
+```
+
+## How It Works
+
+### 1. Node Rendering
+
+The plugin provides a custom render function that:
+
+1. Detects if node topic contains newline characters (`\n`)
+2. If yes, applies multiline styles:
+   - `white-space: pre-wrap` - Preserve line breaks and spaces
+   - `word-break: break-word` - Break long words
+   - `max-width: {text_width}px` - Limit maximum width
+3. If no, uses default rendering
+
+### 2. Node Editing
+
+When editing a node, the plugin:
+
+1. Creates a `<div contenteditable="plaintext-only">` editor
+2. Sets editor styles to match the node element:
+   - Width = node width
+   - Min-height = node height
+   - Auto-expands height based on content
+3. Handles keyboard events:
+   - `Shift + Enter`: Insert line break
+   - `Enter`: Save changes
+   - `Esc`: Cancel editing
+   - `Tab`: Save changes
+4. Auto-expands height on input
+5. Saves changes on blur (with 100ms delay)
+
+### 3. Text Normalization
+
+When saving, the plugin normalizes the text:
+
+```javascript
+const topic = (editor.textContent || '')
+    .trim()                      // Remove leading/trailing whitespace
+    .replace(/\r\n/g, '\n')      // Normalize Windows line endings
+    .replace(/\r/g, '\n')        // Normalize Mac line endings
+    .replace(/\n{3,}/g, '\n\n'); // Limit consecutive blank lines to 2
+```
+
+## Examples
+
+### Example 1: Basic Multiline Text
+
+```javascript
+const mind = {
+    meta: { name: 'Demo', author: 'jsMind', version: '1.0' },
+    format: 'node_tree',
+    data: {
+        id: 'root',
+        topic: 'Multiline Text\nMind Map',
+        children: [
+            {
+                id: 'node1',
+                topic: 'Line 1\nLine 2\nLine 3',
+            },
+        ],
+    },
+};
+
+jm.show(mind);
+```
+
+### Example 2: Programmatically Add Multiline Node
+
+```javascript
+// Add a multiline child node
+jm.add_node(
+    'parent_node_id',
+    'new_node_id',
+    'First line\nSecond line\nThird line'
+);
+```
+
+### Example 3: Update Node to Multiline
+
+```javascript
+// Update existing node to multiline text
+jm.update_node('node_id', 'New line 1\nNew line 2');
+```
+
+## Editor Behavior
+
+### Auto Height Expansion
+
+The editor automatically expands its height based on content:
+
+```javascript
+const autoExpand = () => {
+    editor.style.height = 'auto';
+    editor.style.height = editor.scrollHeight + 'px';
+};
+$.on(editor, 'input', autoExpand);
+setTimeout(autoExpand, 0);  // Initial expand
+```
+
+**Behavior:**
+- Initial height = node height
+- Expands when content exceeds initial height
+- Shrinks when content is deleted (but not below initial height)
+- No scrollbar (overflow: hidden)
+
+### Editor Styles
+
+```css
+.jsmind-multiline-editor {
+    width: {node.clientWidth}px;
+    min-height: {node.clientHeight}px;
+    line-height: {opts.line_height};
+    border: none;
+    outline: none;
+    white-space: pre-wrap;
+    word-break: break-word;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+```
+
+## API Reference
+
+### `createMultilineRender(options)`
+
+Create a custom node render function.
+
+**Type:**
+```typescript
+function createMultilineRender(options?: {
+    text_width?: number;
+    line_height?: string;
+}): (jm: jsMind, element: HTMLElement, node: Node) => boolean
+```
+
+**Example:**
+```javascript
+const render = createMultilineRender({
+    text_width: 250,
+    line_height: '1.6',
+});
+```
+
+## Browser Compatibility
+
+- ✅ Chrome 60+
+- ✅ Firefox 55+
+- ✅ Safari 11+
+- ✅ Edge 79+
+
+**Note:** Requires `contenteditable="plaintext-only"` support.
+
+## Troubleshooting
+
+### Issue: Plugin not working
+
+**Solution:**
+1. Make sure the plugin script is loaded after jsMind core
+2. Check that `custom_node_render` is set in options
+3. Check that `plugin.multiline_text` is configured
+4. Open browser console and look for `[Multiline Plugin] Initializing...`
+
+### Issue: Editor not showing
+
+**Solution:**
+1. Check that the node is editable (`options.editable = true`)
+2. Check browser console for errors
+3. Verify that `contenteditable` is supported in your browser
+
+### Issue: Height not expanding
+
+**Solution:**
+1. Check that `overflow: hidden` is set on the editor
+2. Verify that the `input` event is firing
+3. Check browser console for JavaScript errors
+
+## License
+
+BSD-3-Clause
+
+## Author
+
+UmbraCi
+
+## Links
+
+- [GitHub Repository](https://github.com/hizzgdev/jsmind/)
+- [Documentation](https://hizzgdev.github.io/jsmind/)
+

--- a/docs/zh/plugin-multiline-text.md
+++ b/docs/zh/plugin-multiline-text.md
@@ -1,0 +1,315 @@
+# 多行文本插件
+
+多行文本插件为 jsMind 提供了完整的多行文本支持，包括显示和编辑功能。
+
+## 功能特性
+
+- ✅ **多行文本显示**：在节点中显示多行文本
+- ✅ **多行文本编辑**：使用 `contentEditable` 实现的富文本编辑器
+- ✅ **自动换行**：文本超过最大宽度时自动换行
+- ✅ **自动扩展高度**：编辑器高度随内容自动调整
+- ✅ **键盘快捷键**：
+  - `Shift + Enter`：插入换行符
+  - `Enter`：保存更改
+  - `Esc`：取消编辑
+  - `Tab`：保存更改
+- ✅ **文本规范化**：自动去除首尾空白、统一换行符、限制连续空行
+
+## 安装
+
+### 方式 1：UMD（浏览器）
+
+```html
+<script src="es6/jsmind.js"></script>
+<script src="es6/jsmind.multiline-text.js"></script>
+```
+
+### 方式 2：ES6 模块
+
+```javascript
+import jsMind from './es6/jsmind.js';
+import { createMultilineRender } from './es6/jsmind.multiline-text.js';
+```
+
+## 使用方法
+
+### 基本用法
+
+```javascript
+// UMD（浏览器）
+const options = {
+    container: 'jsmind_container',
+    editable: true,
+    view: {
+        // 使用插件提供的自定义渲染函数
+        custom_node_render: jsMindMultilineText.createMultilineRender({
+            text_width: 200,
+            line_height: '1.5',
+        })
+    },
+    plugin: {
+        multiline_text: {
+            text_width: 200,
+            line_height: '1.5',
+        }
+    }
+};
+
+const jm = new jsMind(options);
+jm.show(mind_data);
+```
+
+### ES6 模块用法
+
+```javascript
+import jsMind from './es6/jsmind.js';
+import { createMultilineRender } from './es6/jsmind.multiline-text.js';
+
+const options = {
+    container: 'jsmind_container',
+    editable: true,
+    view: {
+        custom_node_render: createMultilineRender({
+            text_width: 200,
+            line_height: '1.5',
+        })
+    },
+    plugin: {
+        multiline_text: {
+            text_width: 200,
+            line_height: '1.5',
+        }
+    }
+};
+
+const jm = new jsMind(options);
+jm.show(mind_data);
+```
+
+## 配置选项
+
+### `createMultilineRender(options)`
+
+创建多行文本的自定义节点渲染函数。
+
+**参数：**
+
+| 选项 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `text_width` | `number` | `200` | 多行文本节点的最大宽度（像素） |
+| `line_height` | `string` | `'1.5'` | 文本行高 |
+
+**返回值：** `function(jsMind, HTMLElement, Node): boolean`
+
+**示例：**
+
+```javascript
+const customRender = createMultilineRender({
+    text_width: 250,
+    line_height: '1.6',
+});
+```
+
+### 插件选项
+
+在 `options.plugin.multiline_text` 中配置插件行为：
+
+```javascript
+{
+    plugin: {
+        multiline_text: {
+            text_width: 200,      // 多行文本最大宽度
+            line_height: '1.5',   // 行高
+        }
+    }
+}
+```
+
+## 工作原理
+
+### 1. 节点渲染
+
+插件提供的自定义渲染函数：
+
+1. 检测节点主题是否包含换行符（`\n`）
+2. 如果包含，应用多行样式：
+   - `white-space: pre-wrap` - 保留换行和空格
+   - `word-break: break-word` - 断开长单词
+   - `max-width: {text_width}px` - 限制最大宽度
+3. 如果不包含，使用默认渲染
+
+### 2. 节点编辑
+
+编辑节点时，插件会：
+
+1. 创建 `<div contenteditable="plaintext-only">` 编辑器
+2. 设置编辑器样式以匹配节点元素：
+   - 宽度 = 节点宽度
+   - 最小高度 = 节点高度
+   - 根据内容自动扩展高度
+3. 处理键盘事件：
+   - `Shift + Enter`：插入换行符
+   - `Enter`：保存更改
+   - `Esc`：取消编辑
+   - `Tab`：保存更改
+4. 输入时自动扩展高度
+5. 失焦时保存更改（延迟 100ms）
+
+### 3. 文本规范化
+
+保存时，插件会规范化文本：
+
+```javascript
+const topic = (editor.textContent || '')
+    .trim()                      // 去除首尾空白
+    .replace(/\r\n/g, '\n')      // 统一 Windows 换行符
+    .replace(/\r/g, '\n')        // 统一 Mac 换行符
+    .replace(/\n{3,}/g, '\n\n'); // 限制连续空行最多 2 个
+```
+
+## 示例
+
+### 示例 1：基本多行文本
+
+```javascript
+const mind = {
+    meta: { name: 'Demo', author: 'jsMind', version: '1.0' },
+    format: 'node_tree',
+    data: {
+        id: 'root',
+        topic: '多行文本\n思维导图',
+        children: [
+            {
+                id: 'node1',
+                topic: '第一行\n第二行\n第三行',
+            },
+        ],
+    },
+};
+
+jm.show(mind);
+```
+
+### 示例 2：编程方式添加多行节点
+
+```javascript
+// 添加多行子节点
+jm.add_node(
+    'parent_node_id',
+    'new_node_id',
+    '第一行\n第二行\n第三行'
+);
+```
+
+### 示例 3：更新节点为多行文本
+
+```javascript
+// 更新现有节点为多行文本
+jm.update_node('node_id', '新的第一行\n新的第二行');
+```
+
+## 编辑器行为
+
+### 自动扩展高度
+
+编辑器根据内容自动扩展高度：
+
+```javascript
+const autoExpand = () => {
+    editor.style.height = 'auto';
+    editor.style.height = editor.scrollHeight + 'px';
+};
+$.on(editor, 'input', autoExpand);
+setTimeout(autoExpand, 0);  // 初始扩展
+```
+
+**行为：**
+- 初始高度 = 节点高度
+- 内容超过初始高度时扩展
+- 删除内容时收缩（但不会小于初始高度）
+- 无滚动条（overflow: hidden）
+
+### 编辑器样式
+
+```css
+.jsmind-multiline-editor {
+    width: {node.clientWidth}px;
+    min-height: {node.clientHeight}px;
+    line-height: {opts.line_height};
+    border: none;
+    outline: none;
+    white-space: pre-wrap;
+    word-break: break-word;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+```
+
+## API 参考
+
+### `createMultilineRender(options)`
+
+创建自定义节点渲染函数。
+
+**类型：**
+```typescript
+function createMultilineRender(options?: {
+    text_width?: number;
+    line_height?: string;
+}): (jm: jsMind, element: HTMLElement, node: Node) => boolean
+```
+
+**示例：**
+```javascript
+const render = createMultilineRender({
+    text_width: 250,
+    line_height: '1.6',
+});
+```
+
+## 浏览器兼容性
+
+- ✅ Chrome 60+
+- ✅ Firefox 55+
+- ✅ Safari 11+
+- ✅ Edge 79+
+
+**注意：** 需要支持 `contenteditable="plaintext-only"`。
+
+## 故障排除
+
+### 问题：插件不工作
+
+**解决方案：**
+1. 确保插件脚本在 jsMind 核心之后加载
+2. 检查 `custom_node_render` 是否在 options 中设置
+3. 检查 `plugin.multiline_text` 是否配置
+4. 打开浏览器控制台查看是否有 `[Multiline Plugin] Initializing...`
+
+### 问题：编辑器不显示
+
+**解决方案：**
+1. 检查节点是否可编辑（`options.editable = true`）
+2. 检查浏览器控制台是否有错误
+3. 验证浏览器是否支持 `contenteditable`
+
+### 问题：高度不扩展
+
+**解决方案：**
+1. 检查编辑器是否设置了 `overflow: hidden`
+2. 验证 `input` 事件是否触发
+3. 检查浏览器控制台是否有 JavaScript 错误
+
+## 许可证
+
+BSD-3-Clause
+
+## 作者
+
+UmbraCi
+
+## 链接
+
+- [GitHub 仓库](https://github.com/hizzgdev/jsmind/)
+- [文档](https://hizzgdev.github.io/jsmind/)
+

--- a/example/demo.html
+++ b/example/demo.html
@@ -22,6 +22,7 @@
         <div id="jsmind_container"></div>
         <script type="text/javascript" src="../es6/jsmind.js"></script>
         <script type="text/javascript" src="../es6/jsmind.draggable-node.js"></script>
+        <script type="text/javascript" src="../es6/jsmind.multiline-text.js"></script>
         <script type="text/javascript" src="../features/jsmind.shell.js"></script>
         <script type="text/javascript">
             var _jm = null;
@@ -36,14 +37,14 @@
                     data: [
                         { id: 'root', isroot: true, topic: 'jsMind' },
 
-                        { id: 'sub1', parentid: 'root', topic: 'sub1' },
-                        { id: 'sub11', parentid: 'sub1', topic: 'sub11' },
+                        { id: 'sub1', parentid: 'root', topic: 'Multiline Text\nSupport' },
+                        { id: 'sub11', parentid: 'sub1', topic: 'Line 1\nLine 2\nLine 3' },
                         { id: 'sub12', parentid: 'sub1', topic: 'sub12' },
                         { id: 'sub13', parentid: 'sub1', topic: 'sub13' },
 
-                        { id: 'sub2', parentid: 'root', topic: 'sub2' },
+                        { id: 'sub2', parentid: 'root', topic: 'Features\n- Display\n- Edit' },
                         { id: 'sub21', parentid: 'sub2', topic: 'sub21' },
-                        { id: 'sub22', parentid: 'sub2', topic: 'sub22' },
+                        { id: 'sub22', parentid: 'sub2', topic: 'Auto\nExpand\nHeight' },
 
                         { id: 'sub3', parentid: 'root', topic: 'sub3' },
                     ],
@@ -65,6 +66,16 @@
                     },
                     view: {
                         expander_style: 'char',
+                        custom_node_render: jsMindMultilineText.createMultilineRender({
+                            text_width: 200,
+                            line_height: '1.5',
+                        }),
+                    },
+                    plugin: {
+                        multiline_text: {
+                            text_width: 200,
+                            line_height: '1.5',
+                        },
                     },
                 };
                 _jm = new jsMind(options);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
             "require": "./es6/jsmind.screenshot.js",
             "types": "./types/generated/plugins/jsmind.screenshot.d.ts"
         },
+        "./multiline-text": {
+            "import": "./es6/jsmind.multiline-text.js",
+            "require": "./es6/jsmind.multiline-text.js",
+            "types": "./types/generated/plugins/jsmind.multiline-text.d.ts"
+        },
         "./style/jsmind.css": "./style/jsmind.css"
     },
     "directories": {

--- a/src/plugins/jsmind.multiline-text.js
+++ b/src/plugins/jsmind.multiline-text.js
@@ -185,12 +185,15 @@ function init(jm, options) {
         $.on(editor, 'keydown', e => {
             if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
+                e.stopPropagation(); // Prevent jsMind shortcut from triggering
                 view.edit_node_end();
             } else if (e.key === 'Escape') {
                 e.preventDefault();
+                e.stopPropagation();
                 cancel_editing();
             } else if (e.key === 'Tab') {
                 e.preventDefault();
+                e.stopPropagation();
                 view.edit_node_end();
             }
         });

--- a/src/plugins/jsmind.multiline-text.js
+++ b/src/plugins/jsmind.multiline-text.js
@@ -1,0 +1,301 @@
+/**
+ * @license BSD
+ * @copyright 2014-2025 UmbraCi
+ *
+ * Project Home:
+ *   https://github.com/hizzgdev/jsmind/
+ */
+
+import jsMind from 'jsmind';
+
+const $ = jsMind.$;
+
+/**
+ * Multiline Text Plugin
+ * Provides multiline text support for jsMind nodes
+ */
+
+/**
+ * Default plugin options
+ * @typedef {Object} MultilineTextOptions
+ * @property {number} text_width - Maximum width for multiline text nodes (default: 200)
+ * @property {string} line_height - Line height for text (default: '1.5')
+ */
+const DEFAULT_OPTIONS = {
+    text_width: 200,
+    line_height: '1.5',
+};
+
+/**
+ * Create a custom node render function for multiline text
+ * @param {MultilineTextOptions} [options={}] - Plugin options
+ * @param {number} [options.text_width=200] - Maximum width for multiline text nodes
+ * @param {string} [options.line_height='1.5'] - Line height for text
+ * @returns {function(jsMind, HTMLElement, Node): boolean} Custom render function
+ * @example
+ * const options = {
+ *     view: {
+ *         custom_node_render: createMultilineRender({
+ *             text_width: 250,
+ *             line_height: '1.6',
+ *         })
+ *     }
+ * };
+ */
+export function createMultilineRender(options = {}) {
+    const opts = Object.assign({}, DEFAULT_OPTIONS, options);
+
+    return function (jm, element, node) {
+        if (node.topic && node.topic.includes('\n')) {
+            // Multiline text - apply styles BEFORE setting content
+            element.style.whiteSpace = 'pre-wrap';
+            element.style.wordBreak = 'break-word';
+            element.style.maxWidth = opts.text_width + 'px';
+            element.textContent = node.topic;
+            return true;
+        }
+        // Single line text - use default render
+        return false;
+    };
+}
+
+/**
+ * Re-render all nodes to apply multiline styles and recalculate sizes
+ * @param {import('../jsmind.js').default} jm - jsMind instance
+ * @private
+ */
+function _rerender_all_nodes(jm) {
+    const view = jm.view;
+    const mind = jm.mind;
+
+    if (!mind || !mind.root) {
+        return;
+    }
+
+    // Collect all nodes to update
+    const nodesToUpdate = [];
+    for (const nodeId in mind.nodes) {
+        const node = mind.nodes[nodeId];
+        if (node._data && node._data.view && node._data.view.element) {
+            nodesToUpdate.push(node);
+        }
+    }
+
+    // Batch render nodes (only update DOM, no layout trigger)
+    for (const node of nodesToUpdate) {
+        const element = node._data.view.element;
+        view.render_node(element, node);
+    }
+
+    // Batch update node sizes (read all sizes at once to avoid layout thrashing)
+    for (const node of nodesToUpdate) {
+        if (jm.layout.is_visible(node)) {
+            const element = node._data.view.element;
+            node._data.view.width = element.clientWidth;
+            node._data.view.height = element.clientHeight;
+        }
+    }
+
+    // Finally recalculate layout and show (only trigger reflow/repaint once)
+    jm.layout.layout();
+    jm.view.show(false);
+}
+
+/**
+ * Plugin initialization function
+ * @param {import('../jsmind.js').default} jm - jsMind instance
+ * @param {MultilineTextOptions} options - Plugin options
+ * @private
+ */
+function init(jm, options) {
+    console.log('[Multiline Plugin] Initializing...', options);
+
+    const opts = Object.assign({}, DEFAULT_OPTIONS, options);
+    const view = jm.view;
+
+    // Plugin state
+    let editing_node = null;
+    let multiline_editor = null;
+
+    // IMPORTANT: Re-set view.render_node to use custom render
+    // Because ViewProvider constructor already set it based on options.custom_node_render
+    // We need to ensure it uses the custom render function
+    if (view.opts.custom_node_render) {
+        view.render_node = view._custom_node_render.bind(view);
+        console.log('[Multiline Plugin] Re-bound view.render_node');
+    }
+
+    // Re-render all nodes to apply multiline styles
+    if (jm.mind && jm.mind.root) {
+        _rerender_all_nodes(jm);
+        console.log('[Multiline Plugin] Re-rendered all nodes');
+    }
+
+    /**
+     * Begin editing a node with multiline support
+     * @param {import('../jsmind.node.js').Node} node
+     */
+    view.edit_node_begin = function (node) {
+        console.log('[Multiline Plugin] edit_node_begin called', node);
+        if (!node.topic) {
+            return;
+        }
+
+        // End editing if another node is being edited
+        if (editing_node) {
+            view.edit_node_end();
+        }
+
+        editing_node = node;
+        view.editing_node = node;
+
+        // Create editor (div with contentEditable)
+        const editor = $.c('div');
+        editor.contentEditable = 'plaintext-only';
+        editor.className = 'jsmind-multiline-editor';
+        editor.textContent = node.topic;
+        multiline_editor = editor;
+
+        // Get element and set editor styles to match
+        const element = node._data.view.element;
+
+        // Set editor styles to match element width, auto-expand height
+        Object.assign(editor.style, {
+            width: 'auto',
+            minHeight: element.clientHeight + 'px',
+            lineHeight: opts.line_height,
+            border: 'none',
+            outline: 'none',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            boxSizing: 'border-box',
+            overflow: 'hidden',
+        });
+
+        // Auto-expand height on input
+        const autoExpand = () => {
+            editor.style.height = 'auto';
+            editor.style.height = editor.scrollHeight + 'px';
+        };
+        $.on(editor, 'input', autoExpand);
+        // Initial expand
+        setTimeout(autoExpand, 0);
+
+        // Keyboard events
+        $.on(editor, 'keydown', e => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                view.edit_node_end();
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                cancel_editing();
+            } else if (e.key === 'Tab') {
+                e.preventDefault();
+                view.edit_node_end();
+            }
+        });
+
+        // Blur event - save on blur
+        $.on(editor, 'blur', () => {
+            setTimeout(() => {
+                if (editing_node) {
+                    view.edit_node_end();
+                }
+            }, 100);
+        });
+
+        // Replace node content and focus
+        element.innerHTML = '';
+        element.appendChild(editor);
+        element.style.zIndex = 5;
+        editor.focus();
+
+        // Select all text
+        const range = $.d.createRange();
+        range.selectNodeContents(editor);
+        const selection = $.w.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+    };
+
+    /**
+     * End editing and save changes
+     */
+    view.edit_node_end = function () {
+        if (!editing_node || !multiline_editor) {
+            return;
+        }
+
+        const node = editing_node;
+        const topic = (multiline_editor.textContent || '')
+            .trim()
+            .replace(/\r\n/g, '\n')
+            .replace(/\r/g, '\n')
+            .replace(/\n{3,}/g, '\n\n');
+
+        // Clean up editor
+        cleanup_editor();
+
+        // Update node if content changed
+        if (!jsMind.util.text.is_empty(topic) && node.topic !== topic) {
+            jm.update_node(node.id, topic);
+        } else {
+            view.render_node(node._data.view.element, node);
+        }
+
+        // Focus panel
+        view.e_panel.focus();
+    };
+
+    /**
+     * Cancel editing without saving changes
+     */
+    function cancel_editing() {
+        if (!editing_node || !multiline_editor) {
+            return;
+        }
+
+        const node = editing_node;
+
+        // Clean up editor
+        cleanup_editor();
+
+        // Re-render node
+        view.render_node(node._data.view.element, node);
+
+        // Focus panel
+        view.e_panel.focus();
+    }
+
+    /**
+     * Clean up editor and reset state
+     */
+    function cleanup_editor() {
+        if (!editing_node || !multiline_editor) {
+            return;
+        }
+
+        const element = editing_node._data.view.element;
+
+        // Remove editor
+        if (multiline_editor.parentNode) {
+            multiline_editor.parentNode.removeChild(multiline_editor);
+        }
+
+        // Reset styles and state
+        element.style.zIndex = 'auto';
+        editing_node = null;
+        view.editing_node = null;
+        multiline_editor = null;
+    }
+}
+
+// Register plugin
+jsMind.register_plugin(new jsMind.plugin('multiline_text', init));
+
+// Export for ES6 modules
+export default {
+    name: 'multiline_text',
+    init,
+    createMultilineRender,
+};


### PR DESCRIPTION
## Overview

This PR refactors the multiline text editing functionality into an independent plugin form, following the maintainer's recommendations.

## Key Changes

- **Plugin Refactoring**: Refactored multiline editing functionality into an independent `jsmind.multiline-text.js` plugin
- **Optimized Editor**: Improved editor text processing logic, fixed multiline text encoding/decoding issues
- **Browser Compatibility**: Enhanced HTML entity processing and browser compatibility
- **Build Configuration**: Updated rollup configuration to support new plugin structure
- **Example Updates**: Simplified example page to demonstrate basic plugin usage

## Technical Implementation

- Uses `contenteditable` for multiline editing
- Supports `Shift+Enter` for line breaks, `Enter` to finish editing
- Automatically adjusts node size to accommodate multiline content
- Maintains compatibility with existing jsMind API

## Usage

```javascript
// Load the plugin
import 'jsmind.multiline-text.js';

// Plugin automatically registers when creating jsMind instance
const jm = new jsMind(options);

// Plugin automatically handles multiline text editing and display
```

## Backward Compatibility

- Fully backward compatible, does not affect existing functionality
- Plugin uses non-invasive design, won't impact core jsMind functionality

## Testing

- Tested multiline text editing and display
- Tested compatibility with drag-and-drop plugin
- Tested cross-browser compatibility