### PR TITLE
fix: Using minus sign for perfect expander alignment

### DIFF
--- a/src/jsmind.view_provider.js
+++ b/src/jsmind.view_provider.js
@@ -600,7 +600,7 @@ export class ViewProvider {
             return node.children.length > 99 ? '...' : node.children.length;
         }
         if (style === 'char') {
-            return node.expanded ? '-' : '+';
+            return node.expanded ? '−' : '+';
         }
     }
 


### PR DESCRIPTION
I noticed some strange alignment on the node expander and realized that using the correct minus sign provides a more balanced appearance.

I know this is a reallly small and somewhat edge case pull request, but I believe this minor change makes the UI more visually stable. Apologies if it feels like an unnecessary tweak.

Old hyphen:
<img width="209" height="174" alt="irudia" src="https://github.com/user-attachments/assets/054699ca-9d79-42f0-896f-5320a3dde9c9" />

New minus sign:
<img width="209" height="174" alt="irudia" src="https://github.com/user-attachments/assets/c5c75e11-a266-4648-9f0d-3edfbdb64c2a" />

To me, the minus sign aligns better vertically and results in cleaner visualization, but I completely understand if you'd prefer not to merge this. 🙂



