### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/hizzgdev/jsmind/security/code-scanning/1](https://github.com/hizzgdev/jsmind/security/code-scanning/1)

To resolve this issue, an explicit `permissions` block should be added to the workflow, granting only the minimal permissions required. In this case, the workflow does not require write access to code, issues, or any other GitHub resource—it only checks code out and installs dependencies. Therefore, we should add `permissions: contents: read` at the root level (before `jobs:`), ensuring all jobs inherit this setting unless they explicitly override it.  
Update `.github/workflows/node.js.yml` by adding the following block between the workflow name and the `on:` block:

```yaml
permissions:
  contents: read
```

No changes to any other part of the workflow are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
