### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/src/jsmind.util.js
+++ b/src/jsmind.util.js
@@ -74,6 +74,9 @@ export const util = {
         },
         merge: function (b, a) {
             for (var o in a) {
+                if (o === '__proto__' || o === 'constructor' || o === 'prototype') {
+                    continue;
+                }
                 if (o in b) {
                     if (
                         typeof b[o] === 'object' &&


### PR DESCRIPTION
Potential fix for [https://github.com/hizzgdev/jsmind/security/code-scanning/2](https://github.com/hizzgdev/jsmind/security/code-scanning/2)

To fix this issue, the merge function needs to block the assignment or merging of potentially dangerous special property names (`__proto__`, `constructor`, and possibly `prototype`). The best way to do this is to, inside the loop, skip any keys with those names before assigning or recursing. This can be achieved by adding a simple conditional check at the top of the loop. No external library is required; this can be done inline. Only the function body of `util.json.merge` (lines 75–92) in `src/jsmind.util.js` must be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
