### PR TITLE
Potential fix for code scanning alert no. 3: Prototype-polluting function

### DIFF
--- a/js-legacy/jsmind.js
+++ b/js-legacy/jsmind.js
@@ -994,6 +994,9 @@
             },
             merge: function (b, a) {
                 for (var o in a) {
+                    if (o === '__proto__' || o === 'constructor' || o === 'prototype') {
+                        continue;
+                    }
                     if (o in b) {
                         if (typeof b[o] === 'object' &&
                             Object.prototype.toString.call(b[o]).toLowerCase() == '[object object]' &&


### PR DESCRIPTION
Potential fix for [https://github.com/hizzgdev/jsmind/security/code-scanning/3](https://github.com/hizzgdev/jsmind/security/code-scanning/3)

To fix the prototype pollution vulnerability, we must prevent the function from copying or merging properties with dangerous keys into the destination object. Specifically, block property names such as `"__proto__"`, `"constructor"`, and `"prototype"`, as these can be used to pollute the JavaScript prototype chain. The best, least-disruptive fix is to add a check in the loop so that if the key matches any of those disallowed names, it skips copying or recursing on it.

This change should be applied directly inside the `jm.util.json.merge` function, right after the loop variable is defined in the `for (var o in a)` loop. No new imports or project-wide changes are needed: just add a check like  
`if (o === '__proto__' || o === 'constructor' || o === 'prototype') continue;`.

Places to change:
- **File:** `js-legacy/jsmind.js`
- **Region:** lines 995–1010, inside `jm.util.json.merge`

We should insert the guard as soon as we enter the loop, before any assignment or recursion on `b[o]`. No helper methods or other definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
